### PR TITLE
Separate the output dir for tests from the data dir

### DIFF
--- a/drizzle/tests/test_drizzle.py
+++ b/drizzle/tests/test_drizzle.py
@@ -2,7 +2,11 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 
 import sys
 import math
-import os.path
+import os
+import shutil
+import tempfile
+import pytest
+
 import numpy as np
 import numpy.ma as ma
 import numpy.testing as npt
@@ -12,7 +16,13 @@ from astropy.io import fits
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
-OUTPUT_DIR = os.path.join(TEST_DIR, 'data')
+OUTPUT_DIR = os.environ.get('DRIZZLE_TEST_OUTPUT_DIR', tempfile.mkdtemp())
+
+@pytest.yield_fixture(autouse=True, scope='module')
+def output_dir():
+    yield
+    if 'DRIZZLE_TEST_OUTPUT_DIR' not in os.environ:
+        shutil.rmtree(OUTPUT_DIR)
 
 from .. import drizzle
 

--- a/drizzle/tests/test_drizzle.py
+++ b/drizzle/tests/test_drizzle.py
@@ -12,6 +12,7 @@ from astropy.io import fits
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
+OUTPUT_DIR = os.path.join(TEST_DIR, 'data')
 
 from .. import drizzle
 
@@ -207,8 +208,8 @@ def test_square_with_point():
     Test do_driz square kernel with point
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_square_point.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_square_point.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_square_point.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_square_point.txt')
     output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
     
     insci = read_image(input_file)
@@ -237,8 +238,8 @@ def test_square_with_grid():
     Test do_driz square kernel with grid
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_square_grid.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_square_grid.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_square_grid.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_square_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_square_grid.fits')
     
     insci = read_image(input_file)
@@ -267,8 +268,8 @@ def test_turbo_with_grid():
     Test do_driz turbo kernel with grid
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_turbo_grid.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_turbo_grid.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_turbo_grid.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_turbo_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_turbo_grid.fits')
     
     insci = read_image(input_file)
@@ -297,8 +298,8 @@ def test_gaussian_with_grid():
     Test do_driz gaussian kernel with grid
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_gaussian_grid.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_gaussian_grid.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_gaussian_grid.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_gaussian_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_gaussian_grid.fits')
     
     insci = read_image(input_file)
@@ -327,8 +328,8 @@ def test_lanczos_with_grid():
     Test do_driz lanczos kernel with grid
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_lanczos_grid.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_lanczos_grid.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_lanczos_grid.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_lanczos_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_lanczos_grid.fits')
     
     insci = read_image(input_file)
@@ -357,8 +358,8 @@ def test_tophat_with_grid():
     Test do_driz tophat kernel with grid
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_tophat_grid.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_tophat_grid.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_tophat_grid.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_tophat_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_tophat_grid.fits')
     
     insci = read_image(input_file)
@@ -387,8 +388,8 @@ def test_point_with_grid():
     Test do_driz point kernel with grid
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_point_grid.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_point_grid.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_point_grid.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_point_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_point_grid.fits')
     
     insci = read_image(input_file)
@@ -417,8 +418,8 @@ def test_blot_with_point():
     Test do_blot with point image
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_blot_point.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_blot_point.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_blot_point.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_blot_point.txt')
     output_template = os.path.join(DATA_DIR, 'reference_blot_point.fits')
     
     outsci = read_image(input_file)
@@ -447,8 +448,8 @@ def test_blot_with_default():
     Test do_blot with default grid image
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_blot_default.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_blot_default.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_blot_default.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_blot_default.txt')
     output_template = os.path.join(DATA_DIR, 'reference_blot_default.fits')
     
     outsci = read_image(input_file)
@@ -478,8 +479,8 @@ def test_blot_with_lan3():
     Test do_blot with lan3 grid image
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_blot_lan3.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_blot_lan3.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_blot_lan3.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_blot_lan3.txt')
     output_template = os.path.join(DATA_DIR, 'reference_blot_lan3.fits')
     
     outsci = read_image(input_file)
@@ -509,8 +510,8 @@ def test_blot_with_lan5():
     Test do_blot with lan5 grid image
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(DATA_DIR, 'output_blot_lan5.fits')
-    output_difference = os.path.join(DATA_DIR, 'difference_blot_lan5.txt')
+    output = os.path.join(OUTPUT_DIR, 'output_blot_lan5.fits')
+    output_difference = os.path.join(OUTPUT_DIR, 'difference_blot_lan5.txt')
     output_template = os.path.join(DATA_DIR, 'reference_blot_lan5.fits')
     
     outsci = read_image(input_file)

--- a/drizzle/tests/test_file_io.py
+++ b/drizzle/tests/test_file_io.py
@@ -3,7 +3,10 @@ from __future__ import division, print_function, unicode_literals, absolute_impo
 import sys
 import glob
 import math
-import os.path
+import os
+import shutil
+import tempfile
+import pytest
 import numpy as np
 import numpy.ma as ma
 import numpy.testing as npt
@@ -13,7 +16,13 @@ from astropy.io import fits
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
-OUTPUT_DIR = os.path.join(TEST_DIR, 'data')
+OUTPUT_DIR = os.environ.get('DRIZZLE_TEST_OUTPUT_DIR', tempfile.mkdtemp())
+
+@pytest.yield_fixture(autouse=True, scope='module')
+def output_dir():
+    yield
+    if 'DRIZZLE_TEST_OUTPUT_DIR' not in os.environ:
+        shutil.rmtree(OUTPUT_DIR)
 
 from .. import drizzle
 from .. import util

--- a/drizzle/tests/test_file_io.py
+++ b/drizzle/tests/test_file_io.py
@@ -13,6 +13,7 @@ from astropy.io import fits
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
+OUTPUT_DIR = os.path.join(TEST_DIR, 'data')
 
 from .. import drizzle
 from .. import util
@@ -54,7 +55,7 @@ def test_null_run():
     """
     Create an empty drizzle image
     """
-    output_file = os.path.join(DATA_DIR, 'output_null_run.fits')
+    output_file = os.path.join(OUTPUT_DIR, 'output_null_run.fits')
     output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
 
     output_wcs = read_wcs(output_template)
@@ -86,8 +87,8 @@ def test_file_init():
     """
     Initialize drizzle object from a file
     """
-    input_file = os.path.join(DATA_DIR, 'output_null_run.fits')        
-    output_file = os.path.join(DATA_DIR, 'output_null_run.fits')
+    input_file = os.path.join(OUTPUT_DIR, 'output_null_run.fits')
+    output_file = os.path.join(OUTPUT_DIR, 'output_null_run.fits')
 
     driz = drizzle.Drizzle(infile=input_file)
     driz.write(output_file)
@@ -103,7 +104,7 @@ def test_add_header():
     Add extra keywords read from the header
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')        
-    output_file = os.path.join(DATA_DIR, 'output_add_header.fits')
+    output_file = os.path.join(OUTPUT_DIR, 'output_add_header.fits')
     output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
 
     driz = drizzle.Drizzle(infile=output_template)
@@ -127,8 +128,8 @@ def test_add_file():
     Add an image read from a file
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits[1]')        
-    output_file = os.path.join(DATA_DIR, 'output_add_file.fits')
-    test_file = os.path.join(DATA_DIR, 'output_add_header.fits')
+    output_file = os.path.join(OUTPUT_DIR, 'output_add_file.fits')
+    test_file = os.path.join(OUTPUT_DIR, 'output_add_header.fits')
     output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
 
     driz = drizzle.Drizzle(infile=output_template)
@@ -145,8 +146,8 @@ def test_blot_file():
     Blot an image read from a file
     """
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits[1]')
-    output_file = os.path.join(DATA_DIR, 'output_blot_file.fits')
-    test_file = os.path.join(DATA_DIR, 'output_blot_image.fits')
+    output_file = os.path.join(OUTPUT_DIR, 'output_blot_file.fits')
+    test_file = os.path.join(OUTPUT_DIR, 'output_blot_image.fits')
     output_template = os.path.join(DATA_DIR, 'reference_blot_image.fits')
 
     blotwcs = read_wcs(input_file)


### PR DESCRIPTION
This allows to run the tests when installed, and it also avoids pollution of the test data subdir during a normal test.

By default, the output dir is created in `/tmp` and removed after the test. This can be overwritten with the environment variable `DRIZZLE_TEST_OUTPUT_DIR`, which also inhibits the automatical removal.

This fixes #8.