### PR TITLE
Add check to input of shrinks_segment to prevent checks outside of array

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.4'
+VERSION = '1.5'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
The function shrink_segment in cdrizzlemap.c reduces the segment length to exclude NaN values on either end of the segment. The old version did not check to see if the segment lies entirely inside the bounds of the image, and sometimes it is called with segments like this. I added checks so that the search for NaN values starts on the image and not outside it.