### PR TITLE
Fix out of bounds array error caused by shrink_segment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
         - PIP_DEPENDENCIES=''
         - EVENT_TYPE='pull_request push'
 
-	# For this package-template, we include examples of Cython modules,
+    # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
         - CONDA_DEPENDENCIES='Cython'
@@ -138,9 +138,3 @@ install:
 
 script:
    - $MAIN_CMD $SETUP_CMD
-
-after_success:
-    # If coveralls.io is set up for this package, uncomment the line
-    # below and replace "packagename" with the name of your package.
-    # The coveragerc file may be customized as needed for your package.
-    # - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
-language: python
+# We set the language to c because python isn't supported on the MacOS X nodes
+# on Travis. However, the language ends up being irrelevant anyway, since we
+# install Python ourselves using conda.
+language: c
 
-python:
-    - 2.7
-    - 3.4
+os:
+    - linux
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -25,15 +27,25 @@ env:
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
+        - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
+        - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
         - PIP_DEPENDENCIES=''
+        - EVENT_TYPE='pull_request push'
 
-        # For this package-template, we include examples of Cython modules,
+	# For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include
         # Cython code, you can set CONDA_DEPENDENCIES=''
         - CONDA_DEPENDENCIES='Cython'
+
+        # Conda packages for affiliated packages are hosted in channel
+        # "astropy" while builds for astropy LTS with recent numpy versions
+        # are in astropy-ci-extras. If your package uses either of these,
+        # add the channels to CONDA_CHANNELS along with any other channels
+        # you want to use.
+        - CONDA_CHANNELS='astropy-ci-extras astropy'
 
         # If there are matplotlib or other GUI tests, uncomment the following
         # line to use the X virtual framebuffer.
@@ -41,51 +53,63 @@ env:
 
     matrix:
         # Make sure that egg_info works without dependencies
-        - SETUP_CMD='egg_info'
-        # Try all python versions with the latest numpy
-        - SETUP_CMD='test'
+        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
 matrix:
-    include:
 
-        # Do a coverage test in Python 2.
-        - python: 2.7
+    # Don't wait for allowed failures
+    fast_finish: true
+
+    include:
+        # Try MacOS X
+        - os: osx
+          env: SETUP_CMD='test'
+
+        # Do a coverage test.
+        - os: linux
           env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time
-        #- python: 2.7
-        #  env: SETUP_CMD='build_sphinx -w'
+        - os: linux
+          env: SETUP_CMD='build_docs -w'
 
-        # Try Astropy development version
-        - python: 2.7
+        # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
+        - os: linux
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
+               EVENT_TYPE='pull_request push cron'
+        - os: linux
           env: ASTROPY_VERSION=development
-        - python: 3.4
-          env: ASTROPY_VERSION=development
-        - python: 2.7
+               EVENT_TYPE='pull_request push cron'
+        - os: linux
+          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
+        - os: linux
           env: ASTROPY_VERSION=lts
-        - python: 3.4
-          env: ASTROPY_VERSION=lts
 
-        # Python 3.3 doesn't have numpy 1.10 in conda, but can be put
-        # back into the main matrix once the numpy build is available in the
-        # astropy-ci-extras channel (or in the one provided in the
-        # CONDA_CHANNELS environmental variable).
+        # Try all python versions and Numpy versions. Since we can assume that
+        # the Numpy developers have taken care of testing Numpy with different
+        # versions of Python, we can vary Python and Numpy versions at the same
+        # time.
 
-        - python: 3.3
-          env: SETUP_CMD='egg_info'
-        - python: 3.3
-          env: SETUP_CMD='test' NUMPY_VERSION=1.9
-
-        # Try older numpy versions
-        - python: 2.7
-          env: NUMPY_VERSION=1.10
-        - python: 2.7
-          env: NUMPY_VERSION=1.9
+        - os: linux
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
+        - os: linux
+          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
+        - os: linux
+          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
+        - os: linux
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
+        - os: linux
+          env: NUMPY_VERSION=1.11
 
         # Try numpy pre-release
-        - python: 3.5
+        - os: linux
           env: NUMPY_VERSION=prerelease
+               EVENT_TYPE='pull_request push cron'
 
 install:
 
@@ -113,10 +137,10 @@ install:
     # other dependencies.
 
 script:
-   - python setup.py $SETUP_CMD
+   - $MAIN_CMD $SETUP_CMD
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line
     # below and replace "packagename" with the name of your package.
     # The coveragerc file may be customized as needed for your package.
-    # - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi
+    # - if [[ $SETUP_CMD == *coverage* ]]; then coveralls --rcfile='packagename/tests/coveragerc'; fi

--- a/drizzle/src/cdrizzleapi.c
+++ b/drizzle/src/cdrizzleapi.c
@@ -20,6 +20,7 @@
 #include "tests/drizzletest.h"
 
 static PyObject *gl_Error;
+FILE *driz_log_handle = NULL;
 
 /** --------------------------------------------------------------------------------------------------
  * Multiply each pixel in an image by a scale factor
@@ -83,6 +84,8 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
   struct driz_param_t p;
   integer_t isize[2];
 
+  driz_log_handle = driz_log_init(driz_log_handle);
+  driz_log_message("starting tdriz");
   driz_error_init(&error);
   
   if (!PyArg_ParseTupleAndKeywords(args, keywords, "OOOOOO|lllllddssffs:tdriz", (char **)kwlist,
@@ -219,6 +222,8 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
   }
 
  _exit:
+  driz_log_message("ending tdriz");
+  driz_log_close(driz_log_handle);
   Py_XDECREF(con);
   Py_XDECREF(img); 
   Py_XDECREF(wei); 
@@ -266,6 +271,8 @@ tblot(PyObject *obj, PyObject *args, PyObject *keywords)
   struct driz_param_t p;
   integer_t osize[2];
 
+  driz_log_handle = driz_log_init(driz_log_handle);
+  driz_log_message("starting tnlot");
   driz_error_init(&error);
   
   if (!PyArg_ParseTupleAndKeywords(args, keywords, "OOO|lllldfsfff:tblot", (char **)kwlist,
@@ -332,6 +339,8 @@ tblot(PyObject *obj, PyObject *args, PyObject *keywords)
   if (doblot(&p)) goto _exit;
 
  _exit:
+  driz_log_message("ending tblot");
+  driz_log_close(driz_log_handle);
   Py_DECREF(img);
   Py_DECREF(out);
   Py_DECREF(map);

--- a/drizzle/src/cdrizzleblot.c
+++ b/drizzle/src/cdrizzleblot.c
@@ -888,6 +888,7 @@ doblot(struct driz_param_t* p) {
   struct lanczos_param_t lanczos;
   void* state = NULL;
   
+  driz_log_message("starting doblot");
   get_dimensions(p->data, isize);
   get_dimensions(p->output_data, osize);
 
@@ -973,6 +974,7 @@ doblot(struct driz_param_t* p) {
   }
 
  doblot_exit_:
+  driz_log_message("ending doblot");
   if (lanczos.lut) free(lanczos.lut);
 
   return driz_error_is_set(p->error);

--- a/drizzle/src/cdrizzlebox.c
+++ b/drizzle/src/cdrizzlebox.c
@@ -27,7 +27,8 @@ update_data(struct driz_param_t* p, const integer_t ii, const integer_t jj,
             const float d, const float vc, const float dow) {
 
   const double vc_plus_dow = vc + dow;
-
+  driz_log_message("starting update_data");
+  
   /* Just a simple calculation without logical tests */
   if (vc == 0.0) {
     if (oob_pixel(p->output_data, ii, jj)) {
@@ -55,6 +56,7 @@ update_data(struct driz_param_t* p, const integer_t ii, const integer_t jj,
     set_pixel(p->output_counts, ii, jj, vc_plus_dow);
   }
 
+  driz_log_message("ending update_data");
   return 0;
 }
 
@@ -100,6 +102,7 @@ compute_area(double is, double js, const double x[4], const double y[4]) {
    * computed width is positive for two of the sides and negative for the other two,
    * we subtract the area outside the quadrilateral without any extra code.
    */
+  driz_log_message("starting compute_area");
   area = 0.0;
 
   border[0][0] = is - 0.5;
@@ -200,7 +203,8 @@ compute_area(double is, double js, const double x[4], const double y[4]) {
     _nextsegment: continue;
   }
 
-   return fabs(area);
+  driz_log_message("ending compute_area");
+  return fabs(area);
 }
 
 /** --------------------------------------------------------------------------------------------------
@@ -846,7 +850,8 @@ do_kernel_square(struct driz_param_t* p) {
   double dh, jaco, tem, dover, w;
   double xyin[4][2], xyout[2], xout[4], yout[4];
   int margin;
-  
+
+  driz_log_message("starting do_kernel_square");  
   dh = 0.5 * p->pixel_fraction;
   bv = compute_bit_value(p->uuid);
   scale2 = p->scale * p->scale;
@@ -980,6 +985,7 @@ do_kernel_square(struct driz_param_t* p) {
     }
   }
 
+  driz_log_message("ending do_kernel_square");
   return 0;
 }
 
@@ -1009,7 +1015,8 @@ kernel_handler_map[] = {
 int
 dobox(struct driz_param_t* p) {
   kernel_handler_t kernel_handler = NULL;
-
+  driz_log_message("starting dobox");
+  
   /* Set up a function pointer to handle the appropriate kernel */
   if (p->kernel < kernel_LAST) {
     kernel_handler = kernel_handler_map[p->kernel];
@@ -1023,5 +1030,6 @@ dobox(struct driz_param_t* p) {
     driz_error_set_message(p->error, "Invalid kernel type");
   }
  
+  driz_log_message("ending dobox");
   return driz_error_is_set(p->error);
 }

--- a/drizzle/src/cdrizzlemap.h
+++ b/drizzle/src/cdrizzlemap.h
@@ -31,6 +31,7 @@ show_segment(struct segment *self,
 void
 shrink_segment(struct segment *self,
                PyArrayObject *pixmap,
+               PyArrayObject *data,
                int jdim);
 
 void
@@ -52,6 +53,7 @@ map_point(PyArrayObject * pixmap,
 
 int
 clip_bounds(PyArrayObject *pixmap,
+            PyArrayObject *data,
             struct segment *xylimit,
             struct segment *xybounds
            );

--- a/drizzle/src/tests/utest_cdrizzle.c
+++ b/drizzle/src/tests/utest_cdrizzle.c
@@ -387,7 +387,7 @@ FCT_BGN_FN(utest_cdrizzle)
             initialize_segment(&xylimits, p->xmin, p->ymin, p->xmax, p->ymin);  
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmax, p->ymin);  
             
-            shrink_segment(&xybounds, p->pixmap, 0);
+            shrink_segment(&xybounds, p->pixmap, p->data, 0);
             
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
@@ -411,7 +411,7 @@ FCT_BGN_FN(utest_cdrizzle)
             initialize_segment(&xylimits, p->xmin, p->ymin, p->xmin, p->ymax);  
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmin, p->ymax);  
             
-            shrink_segment(&xybounds, p->pixmap, 1);
+            shrink_segment(&xybounds, p->pixmap, p->data, 1);
             
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
@@ -441,7 +441,7 @@ FCT_BGN_FN(utest_cdrizzle)
             initialize_segment(&xylimits, nan_max, p->ymin, p->xmax, p->ymin);  
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmax, p->ymin);  
             
-            shrink_segment(&xybounds, p->pixmap, 0);
+            shrink_segment(&xybounds, p->pixmap, p->data, 0);
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
                     fct_chk_eq_dbl(xybounds.point[i][j], xylimits.point[i][j]);
@@ -457,14 +457,13 @@ FCT_BGN_FN(utest_cdrizzle)
             int i, j;
             struct driz_param_t *p;
             struct segment xybounds;
-            struct segment xylimits;
             
             p = setup_parameters();            
             nan_pixmap(p);
 
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmax, p->ymin);  
             
-            shrink_segment(&xybounds, p->pixmap, 0);
+            shrink_segment(&xybounds, p->pixmap, p->data, 0);
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
                     fct_chk_eq_dbl(xybounds.point[i][j], 0.0);

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.6'
+VERSION = '1.7'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.5'
+VERSION = '1.6'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
Drizzle computes the overlap between each line of the input image and the output image. Part of the computation is shrink_segment, which reduces the length of the input image line if there are NaN values along the edge of the image. That code mistakenly assumed that the size of the input image and pixel map were the same, leading to the out of bounds error when the pixel map was larger. The code in shrink_segment has been modified to intialize the line length from the input image and not the pixel map.

Some logging code has been added to cdrizzleutil.h and various functions to make catching errors easier in the future. The code is controlled by a C macro, LOGGING, and is usually turned off. There is a new global variable, driz_log_handle, defined in cdrizzleapi, initiallized to NULL.