### PR TITLE
Add pixmap dimension check to drizzle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
         # time.
 
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.10
         - os: linux
           env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
         - os: linux

--- a/drizzle/src/cdrizzleapi.c
+++ b/drizzle/src/cdrizzleapi.c
@@ -82,7 +82,7 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
   float inv_exposure_time;
   struct driz_error_t error;
   struct driz_param_t p;
-  integer_t isize[2];
+  integer_t psize[2], isize[2];
 
   driz_log_handle = driz_log_init(driz_log_handle);
   driz_log_message("starting tdriz");
@@ -157,9 +157,16 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
 #endif
   }
 
-  /* Set the area to be processed */
-  
+  get_dimensions(map, psize);
   get_dimensions(img, isize);
+  
+  if (psize[0] != isize[0] || psize[1] != isize[1]) {
+    driz_error_set_message(&error, "Pixel map dimensions != input dimensions");
+    goto _exit;
+  }
+
+  /* Set the area to be processed */
+
   if (xmax == 0) xmax = isize[0];
   if (ymax == 0) ymax = isize[1];
   
@@ -269,7 +276,7 @@ tblot(PyObject *obj, PyObject *args, PyObject *keywords)
   int istat = 0;
   struct driz_error_t error;
   struct driz_param_t p;
-  integer_t osize[2];
+  integer_t psize[2], osize[2];
 
   driz_log_handle = driz_log_init(driz_log_handle);
   driz_log_message("starting tblot");
@@ -306,7 +313,14 @@ tblot(PyObject *obj, PyObject *args, PyObject *keywords)
     goto _exit;
   }
 
+  get_dimensions(map, psize);
   get_dimensions(out, osize);
+  
+  if (psize[0] != osize[0] || psize[1] != osize[1]) {
+    driz_error_set_message(&error, "Pixel map dimensions != output dimensions");
+    goto _exit;
+  }
+
   if (xmax == 0) xmax = osize[0];
   if (ymax == 0) ymax = osize[1];
 

--- a/drizzle/src/cdrizzleapi.c
+++ b/drizzle/src/cdrizzleapi.c
@@ -157,22 +157,9 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
 #endif
   }
 
-  get_dimensions(img, isize);
-  get_dimensions(map, psize);
-  get_dimensions(wei, wsize);
-  
-  if (psize[0] != isize[0] || psize[1] != isize[1]) {
-    driz_error_set_message(&error, "Pixel map dimensions != input dimensions");
-    goto _exit;
-  }
-
-  if (wsize[0] != isize[0] || wsize[1] != isize[1]) {
-    driz_error_set_message(&error, "Weights array  dimensions != input dimensions");
-    goto _exit;
-  }
-  
   /* Set the area to be processed */
 
+  get_dimensions(img, isize);
   if (xmax == 0) xmax = isize[0];
   if (ymax == 0) ymax = isize[1];
   
@@ -216,7 +203,7 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
   p.weight_scale = wtscl;
   p.fill_value = fill_value;
   p.error = &error;
-
+  
   if (driz_error_check(&error, "xmin must be >= 0", p.xmin >= 0)) goto _exit;
   if (driz_error_check(&error, "ymin must be >= 0", p.ymin >= 0)) goto _exit;
   if (driz_error_check(&error, "xmax must be > xmin", p.xmax > p.xmin)) goto _exit;
@@ -224,6 +211,20 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
   if (driz_error_check(&error, "scale must be > 0", p.scale > 0.0)) goto _exit;
   if (driz_error_check(&error, "exposure time must be > 0", p.exposure_time)) goto _exit;
   if (driz_error_check(&error, "weight scale must be > 0", p.weight_scale > 0.0)) goto _exit;
+  
+  get_dimensions(p.pixmap, psize);
+  if (psize[0] != isize[0] || psize[1] != isize[1]) {
+    driz_error_set_message(&error, "Pixel map dimensions != input dimensions");
+    goto _exit;
+  }
+  
+  if (p.weights) {
+    get_dimensions(p.weights, wsize);
+    if (wsize[0] != isize[0] || wsize[1] != isize[1]) {
+      driz_error_set_message(&error, "Weights array  dimensions != input dimensions");
+      goto _exit;
+    }
+  }
   
   if (dobox(&p)) {
     goto _exit;

--- a/drizzle/src/cdrizzleapi.c
+++ b/drizzle/src/cdrizzleapi.c
@@ -82,7 +82,7 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
   float inv_exposure_time;
   struct driz_error_t error;
   struct driz_param_t p;
-  integer_t psize[2], isize[2];
+  integer_t isize[2], psize[2], wsize[2];
 
   driz_log_handle = driz_log_init(driz_log_handle);
   driz_log_message("starting tdriz");
@@ -157,14 +157,20 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
 #endif
   }
 
-  get_dimensions(map, psize);
   get_dimensions(img, isize);
+  get_dimensions(map, psize);
+  get_dimensions(wei, wsize);
   
   if (psize[0] != isize[0] || psize[1] != isize[1]) {
     driz_error_set_message(&error, "Pixel map dimensions != input dimensions");
     goto _exit;
   }
 
+  if (wsize[0] != isize[0] || wsize[1] != isize[1]) {
+    driz_error_set_message(&error, "Weights array  dimensions != input dimensions");
+    goto _exit;
+  }
+  
   /* Set the area to be processed */
 
   if (xmax == 0) xmax = isize[0];

--- a/drizzle/src/cdrizzlebox.c
+++ b/drizzle/src/cdrizzlebox.c
@@ -27,7 +27,6 @@ update_data(struct driz_param_t* p, const integer_t ii, const integer_t jj,
             const float d, const float vc, const float dow) {
 
   const double vc_plus_dow = vc + dow;
-  driz_log_message("starting update_data");
   
   /* Just a simple calculation without logical tests */
   if (vc == 0.0) {
@@ -56,7 +55,6 @@ update_data(struct driz_param_t* p, const integer_t ii, const integer_t jj,
     set_pixel(p->output_counts, ii, jj, vc_plus_dow);
   }
 
-  driz_log_message("ending update_data");
   return 0;
 }
 
@@ -102,7 +100,6 @@ compute_area(double is, double js, const double x[4], const double y[4]) {
    * computed width is positive for two of the sides and negative for the other two,
    * we subtract the area outside the quadrilateral without any extra code.
    */
-  driz_log_message("starting compute_area");
   area = 0.0;
 
   border[0][0] = is - 0.5;
@@ -203,7 +200,6 @@ compute_area(double is, double js, const double x[4], const double y[4]) {
     _nextsegment: continue;
   }
 
-  driz_log_message("ending compute_area");
   return fabs(area);
 }
 

--- a/drizzle/src/cdrizzlemap.c
+++ b/drizzle/src/cdrizzlemap.c
@@ -353,7 +353,7 @@ clip_bounds(PyArrayObject *pixmap, struct segment *xylimit,
   xybounds->invalid = 1; /* Track if bounds are both outside the image */
   
   for (idim = 0; idim < 2; ++idim) {
-      for (ipoint = 0; ipoint < 2; ++ipoint) {
+    for (ipoint = 0; ipoint < 2; ++ipoint) {
       int m = 21;         /* maximum iterations */
       int side = 0;       /* flag indicating which side moved last */
   

--- a/drizzle/src/cdrizzlemap.h
+++ b/drizzle/src/cdrizzlemap.h
@@ -31,8 +31,8 @@ show_segment(struct segment *self,
 void
 shrink_segment(struct segment *self,
                PyArrayObject *pixmap,
-               PyArrayObject *weights,
-               int jdim);
+               PyArrayObject *weights
+               );
 
 void
 sort_segment(struct segment *self,
@@ -53,7 +53,6 @@ map_point(PyArrayObject * pixmap,
 
 int
 clip_bounds(PyArrayObject *pixmap,
-            PyArrayObject *weights,
             struct segment *xylimit,
             struct segment *xybounds
            );

--- a/drizzle/src/cdrizzlemap.h
+++ b/drizzle/src/cdrizzlemap.h
@@ -31,6 +31,7 @@ show_segment(struct segment *self,
 void
 shrink_segment(struct segment *self,
                PyArrayObject *pixmap,
+               PyArrayObject *weights,
                int jdim);
 
 void
@@ -52,7 +53,7 @@ map_point(PyArrayObject * pixmap,
 
 int
 clip_bounds(PyArrayObject *pixmap,
-            PyArrayObject *data,
+            PyArrayObject *weights,
             struct segment *xylimit,
             struct segment *xybounds
            );

--- a/drizzle/src/cdrizzlemap.h
+++ b/drizzle/src/cdrizzlemap.h
@@ -30,7 +30,7 @@ show_segment(struct segment *self,
 
 void
 shrink_segment(struct segment *self,
-               PyArrayObject *data,
+               PyArrayObject *pixmap,
                int jdim);
 
 void

--- a/drizzle/src/cdrizzleutil.h
+++ b/drizzle/src/cdrizzleutil.h
@@ -4,7 +4,7 @@
 
 #include <Python.h>
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_10_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif
 #include <numpy/arrayobject.h>
 
@@ -202,9 +202,14 @@ driz_log_message(const char* message) {
 }
 
 #else
-#define driz_log_init(handle) NULL
-#define driz_log_close(handle) 0
-#define driz_log_message(message) 0
+static inline_macro void *
+driz_log_idem(void *ptr) {
+    return ptr;
+}
+
+#define driz_log_init(handle) driz_log_idem(handle)
+#define driz_log_close(handle) driz_log_idem(handle)
+#define driz_log_message(message) driz_log_idem(message)
 #endif
 
 /****************************************************************************/

--- a/drizzle/src/cdrizzleutil.h
+++ b/drizzle/src/cdrizzleutil.h
@@ -241,7 +241,8 @@ oob_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix) {
   if (ypix < 0 || ypix >= ndim[0]) flag = 1;
 
   if (flag) {
-    sprintf(buffer, "OOB in output data [%d,%d]", xpix, ypix);
+    sprintf(buffer, "Point [%d,%d] is outside of [%d, %d]",
+            xpix, ypix, (int) ndim[1], (int) ndim[0]);
     driz_log_message(buffer);
   }
   

--- a/drizzle/src/tests/utest_cdrizzle.c
+++ b/drizzle/src/tests/utest_cdrizzle.c
@@ -387,7 +387,7 @@ FCT_BGN_FN(utest_cdrizzle)
             initialize_segment(&xylimits, p->xmin, p->ymin, p->xmax, p->ymin);  
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmax, p->ymin);  
             
-            shrink_segment(&xybounds, p->pixmap, p->weights, 0);
+            shrink_segment(&xybounds, p->pixmap, p->weights);
             
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
@@ -411,7 +411,7 @@ FCT_BGN_FN(utest_cdrizzle)
             initialize_segment(&xylimits, p->xmin, p->ymin, p->xmin, p->ymax);  
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmin, p->ymax);  
             
-            shrink_segment(&xybounds, p->pixmap, p->weights, 1);
+            shrink_segment(&xybounds, p->pixmap, p->weights);
             
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
@@ -441,7 +441,7 @@ FCT_BGN_FN(utest_cdrizzle)
             initialize_segment(&xylimits, nan_max, p->ymin, p->xmax, p->ymin);  
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmax, p->ymin);  
             
-            shrink_segment(&xybounds, p->pixmap, p->weights, 0);
+            shrink_segment(&xybounds, p->pixmap, p->weights);
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
                     fct_chk_eq_dbl(xybounds.point[i][j], xylimits.point[i][j]);
@@ -463,7 +463,7 @@ FCT_BGN_FN(utest_cdrizzle)
 
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmax, p->ymin);  
             
-            shrink_segment(&xybounds, p->pixmap, p->weights, 0);
+            shrink_segment(&xybounds, p->pixmap, p->weights);
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
                     fct_chk_eq_dbl(xybounds.point[i][j], 0.0);

--- a/drizzle/src/tests/utest_cdrizzle.c
+++ b/drizzle/src/tests/utest_cdrizzle.c
@@ -387,7 +387,7 @@ FCT_BGN_FN(utest_cdrizzle)
             initialize_segment(&xylimits, p->xmin, p->ymin, p->xmax, p->ymin);  
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmax, p->ymin);  
             
-            shrink_segment(&xybounds, p->data, 0);
+            shrink_segment(&xybounds, p->pixmap, p->weights, 0);
             
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
@@ -411,7 +411,7 @@ FCT_BGN_FN(utest_cdrizzle)
             initialize_segment(&xylimits, p->xmin, p->ymin, p->xmin, p->ymax);  
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmin, p->ymax);  
             
-            shrink_segment(&xybounds, p->data, 1);
+            shrink_segment(&xybounds, p->pixmap, p->weights, 1);
             
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
@@ -441,7 +441,7 @@ FCT_BGN_FN(utest_cdrizzle)
             initialize_segment(&xylimits, nan_max, p->ymin, p->xmax, p->ymin);  
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmax, p->ymin);  
             
-            shrink_segment(&xybounds, p->data, 0);
+            shrink_segment(&xybounds, p->pixmap, p->weights, 0);
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
                     fct_chk_eq_dbl(xybounds.point[i][j], xylimits.point[i][j]);
@@ -463,7 +463,7 @@ FCT_BGN_FN(utest_cdrizzle)
 
             initialize_segment(&xybounds, p->xmin, p->ymin, p->xmax, p->ymin);  
             
-            shrink_segment(&xybounds, p->data, 0);
+            shrink_segment(&xybounds, p->pixmap, p->weights, 0);
             for (i = 0; i < 2; ++i) {
                 for (j = 0; j < 2; ++j) {
                     fct_chk_eq_dbl(xybounds.point[i][j], 0.0);

--- a/drizzle/src/tests/utest_cdrizzle.c
+++ b/drizzle/src/tests/utest_cdrizzle.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <Python.h>
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_10_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif
 #include <numpy/arrayobject.h>
 #include <numpy/npy_math.h>

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.8'
+VERSION = '1.9'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
The drizzle code expects that the dimensions of the input image and pixmap file are the same. The blotting code expects the dimensions of the output image and pixmap file are the same. Prior to this change, the C code would throw a segmentation violation if the pixmap did not meet this condition. This change adds a check and throws an explicit error if the condition is not met. If your pixmap is larger than the input/output image, it can be trimmmed to match the dimensions. If it is smaller, resize it to have the correct dimensions and fill the undefined pixels with NaN and the function shrink_segment will see that only the corresponding section of the input image is used in the
drizzle. Some diagnostic prints used in debugging C errors are also modified in this change. They are turned off in production. This new test may explicitly break existing code, but it was going to fail
anyway with a harder to debug segmentation violation.