### PR TITLE
Have proper bounds when interpolating in pixmap or fail gracefully

### DIFF
--- a/drizzle/src/cdrizzlemap.h
+++ b/drizzle/src/cdrizzlemap.h
@@ -28,10 +28,22 @@ show_segment(struct segment *self,
              char *str
             );
 
+int
+bad_pixel(PyArrayObject *pixmap,
+          int i,
+          int j
+          );
+
+int
+bad_weight(PyArrayObject *weights,
+           int i,
+           int j
+           );
+
 void
 shrink_segment(struct segment *self,
-               PyArrayObject *pixmap,
-               PyArrayObject *weights
+               PyArrayObject *array,
+               int (*is_bad_value)(PyArrayObject *, int, int)
                );
 
 void
@@ -45,10 +57,17 @@ union_of_segments(int npoint, int jdim,
                   integer_t bounds[2]
                  );
 
-void
+int
 map_point(PyArrayObject * pixmap,
           const double xyin[2],
           double xyout[2]
+         );
+
+int
+map_pixel(PyArrayObject *pixmap, 
+          int    i,
+          int    j,
+          double xyout[2] 
          );
 
 int

--- a/drizzle/src/cdrizzleutil.h
+++ b/drizzle/src/cdrizzleutil.h
@@ -196,6 +196,9 @@ driz_log_close(FILE *handle) {
 
 static inline_macro int
 driz_log_message(const char* message) {
+    if (! driz_log_handle)
+        driz_log_handle = driz_log_init(driz_log_handle);
+
     fputs(message, driz_log_handle);
     fputs("\n", driz_log_handle);
     return 0;

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.9'
+VERSION = '1.10'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
A recent change in the pipeline code has resulted in the pixmap only being partially populated with values mapping from the input to output images. The remainder of the pixmap is populated with NaNs. When mapping a point between the input and output image, one must first find a bound, a set of four pixels that allows one to do an interpolation or extrapolation in two dimensions. The bound does not need to be the immediate neighbors of the interpolated point, but does need to be in the bordering rows and columns of the point. For this reason the interpolation fails if a bordering row or column is entirely NaNs. This typically happens when spectra are being drizzled, the defined area of the pixmap is only a subregion of the detector image.
To handle this common situation, the drizzle code was modified by rewriting shrink_segment to compute the rectangle holding all the defined values in the pixmap. This rectangle can also hold some undefined values (NaNs), so the code to calculate the interpolation bounds (now named interpolation_bounds) was rewritten to recognize the case when the search for a bounds fails and return a flag indicating the failure. (One indicates failure, zero indicates success.) This flag "bubbles up" to do_kernel_square, where it is checked for, and if found, the pixel is skipped and marked as a miss in the drizzle calculation. The other kernels in cdrizzlebox were also modified to skip flagged pixels.