### PR TITLE
Remove python 3.3 from matrix of versions to be tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ env:
     matrix:
         # Make sure that egg_info works without dependencies
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'


### PR DESCRIPTION
Recent versions of numpy only support 3.4 or greater.