### PR TITLE
Add header files to package_info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,8 +97,6 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.10
         - os: linux
-          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
-        - os: linux
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ env:
     matrix:
         # Make sure that egg_info works without dependencies
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.10'
+VERSION = '1.11'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ for entry_point in entry_point_list:
 c_files = []
 for root, dirs, files in os.walk(PACKAGENAME):
     for filename in files:
-        if filename.endswith('.c'):
+        if filename.endswith('.c') or filename.endswith('.h'):
             c_files.append(
                 os.path.join(
                     os.path.relpath(root, PACKAGENAME), filename))


### PR DESCRIPTION
The C header files need to be included when building the source distribution.  I also bumped the version number, in preparation for a PyPi release.

