### PR TITLE
Support NaN as a fill value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,60 +3,64 @@
 # install Python ourselves using conda.
 language: c
 
+compiler: gcc
+
+# Cache can be cleared from the travis settings menu, see docs currently at
+# https://docs.travis-ci.com/user/caching#Clearing-Caches
+cache:
+  - ccache
+
 os:
     - linux
+
+stage: Comprehensive tests
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
-# The apt packages below are needed for sphinx builds. A full list of packages
-# that can be included can be found here:
-#
-# https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise
-
+# The apt packages below are needed for sphinx builds, which can no longer
+# be installed with sudo apt-get.
 addons:
     apt:
         packages:
             - graphviz
-            - texlive-latex-extra
-            - dvipng
+            - language-pack-de
 
 env:
     global:
-
-        # The following versions are the 'default' for tests, unless
-        # overridden underneath. They are defined here in order to save having
-        # to repeat them for all configurations.
+        # Set defaults to avoid repeating in most cases
         - PYTHON_VERSION=3.6
-        - NUMPY_VERSION=stable
-        - ASTROPY_VERSION=stable
+	- NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - SETUP_CMD='test'
-        - PIP_DEPENDENCIES=''
-        - EVENT_TYPE='pull_request push'
-
-    # For this package-template, we include examples of Cython modules,
-        # so Cython is required for testing. If your package does not include
-        # Cython code, you can set CONDA_DEPENDENCIES=''
         - CONDA_DEPENDENCIES='Cython'
+        - CONDA_ALL_DEPENDENCIES='astropy Cython'
+        - SETUP_XVFB=True
+        - EVENT_TYPE='push pull_request'
+        - SETUP_CMD='test'
 
-        # Conda packages for affiliated packages are hosted in channel
-        # "astropy" while builds for astropy LTS with recent numpy versions
-        # are in astropy-ci-extras. If your package uses either of these,
-        # add the channels to CONDA_CHANNELS along with any other channels
-        # you want to use.
-        - CONDA_CHANNELS='astropy-ci-extras astropy'
+        # PEP8 errors/warnings:
+        # E101 - mix of tabs and spaces
+        # W191 - use of tabs
+        # W291 - trailing whitespace
+        # W292 - no newline at end of file
+        # W293 - trailing whitespace
+        # W391 - blank line at end of file
+        # E111 - 4 spaces per indentation level
+        # E112 - 4 spaces per indentation level
+        # E113 - 4 spaces per indentation level
+        # E502 - the backslash is redundant between brackets
+        # E722 - do not use bare except
+        # E901 - SyntaxError or IndentationError
+        # E902 - IOError
+        - FLAKE8_OPT="--select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902"
 
-        # If there are matplotlib or other GUI tests, uncomment the following
-        # line to use the X virtual framebuffer.
-        # - SETUP_XVFB=True
-
-    matrix:
-        # Make sure that egg_info works without dependencies
-        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+stages:
+   # Do the style check and a single test job, don't proceed if it fails
+   - name: Initial tests
+   # Do the rest of the tests
+   - name: Comprehensive tests
+   - name: Cron tests
+     if: type = cron
 
 matrix:
 
@@ -64,74 +68,124 @@ matrix:
     fast_finish: true
 
     include:
-        # Try MacOS X
-        - os: osx
-          env: SETUP_CMD='test'
 
-        # Do a coverage test.
-        - os: linux
-          env: SETUP_CMD='test --coverage'
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+
+        # Try MacOS X. Use a slightly old numpy version to help test against
+        # all supported numpy versions.
+        - os: osx
+          stage: Cron tests
+          env: SETUP_CMD='test --remote-data=astropy'
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PIP_DEPENDENCIES='' EVENT_TYPE='cron'
 
         # Check for sphinx doc build warnings - we do this first because it
-        # may run for a long time
+        # runs for a long time. The sphinx build also has some additional
+        # dependencies. Using a more stringent locale than UTF-8.
         - os: linux
           env: SETUP_CMD='build_docs -w'
-
-        # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
-        - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development
-               EVENT_TYPE='pull_request push cron'
-        - os: linux
-          env: ASTROPY_VERSION=development
-               EVENT_TYPE='pull_request push cron'
-        - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts
-        - os: linux
-          env: ASTROPY_VERSION=lts
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PIP_DEPENDENCIES=''
+               LC_CTYPE=C LC_ALL=C LANG=C
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different
         # versions of Python, we can vary Python and Numpy versions at the same
-        # time.
-
-        - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.10
-        - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
+        # time. Since we test the latest Numpy as part of the builds with all
+        # optional dependencies below, we can focus on older builds here.
+        # Numpy 1.11 is tested below, 1.12 in the Initial stage test.
+        # Run this test using native pytest
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
-        - os: linux
-          env: NUMPY_VERSION=1.11
+               INSTALL_CMD='python setup.py build_ext --inplace'
+               PIP_DEPENDENCIES='pytest-astropy'
+               TEST_CMD='pytest --open-files --doctest-rst'
+          script:
+            - $INSTALL_CMD
+            - $TEST_CMD
 
-        # Try numpy pre-release
+        # Now try with all optional dependencies.
+        - os: linux
+          env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy'
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PIP_DEPENDENCIES="jplephem $ASDF_GIT"
+               LC_CTYPE=C.ascii LC_ALL=C
+               NUMPY_VERSION=1.11
+               MATPLOTLIB_VERSION=1.5
+
+        - os: linux
+          stage: Initial tests
+          env: CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PYTEST_VERSION='>3.2'
+               SETUP_CMD='test -a "--durations=50"'
+          compiler: clang
+
+        # Pinning conda version temporarily to 4.3.21, as some anaconda
+        # packges build with 4.3.27 are faulty and we see this job failing,
+        # while locally there are no issues when the same version of
+        # packages are installed from pip.
+        # TODO: remove the pinning once the issue is solved upstream.
+        - os: linux
+          env: SETUP_CMD='test --coverage --remote-data=astropy'
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PIP_DEPENDENCIES=""
+               LC_CTYPE=C.ascii LC_ALL=C
+               CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
+               MATPLOTLIB_VERSION=2.0 NUMPY_VERSION=1.13
+               EVENT_TYPE='push pull_request cron'
+               CONDA_VERSION=4.3.21
+
+        # Try pre-release version of Numpy without optional dependencies
         - os: linux
           env: NUMPY_VERSION=prerelease
-               EVENT_TYPE='pull_request push cron'
+               EVENT_TYPE='push pull_request cron'
+
+        # Try older numpy versions
+        - os: linux
+          env: NUMPY_VERSION=1.12
+               EVENT_TYPE='push pull_request cron'
+
+        # Do a PEP8/pyflakes test with flake8
+        - os: linux
+          stage: Initial tests
+          env: MAIN_CMD="flake8 astropy --count $FLAKE8_OPT" SETUP_CMD=''
+
+        # Try developer version of Numpy with optional dependencies and also
+        # run all remote tests. Since both cases will be potentially
+        # unstable, we combine them into a single unstable build that we can
+        # mark as an allowed failure below.
+        - os: linux
+          env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+
+        # We check numpy-dev also in a job that only runs from cron, so that
+        # we can spot issues sooner. We do not use remote data here, since
+        # that gives too many false positives due to URL timeouts.
+        - os: linux
+          stage: Cron tests
+          env: NUMPY_VERSION=dev EVENT_TYPE='cron'
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+
+    allow_failures:
+      - os: linux
+        env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
+             CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
 
 install:
-
-    # We now use the ci-helpers package to set up our testing environment.
-    # This is done by using Miniconda and then using conda and pip to install
-    # dependencies. Which dependencies are installed using conda and pip is
-    # determined by the CONDA_DEPENDENCIES and PIP_DEPENDENCIES variables,
-    # which should be space-delimited lists of package names. See the README
-    # in https://github.com/astropy/ci-helpers for information about the full
-    # list of environment variables that can be used to customize your
-    # environment. In some cases, ci-helpers may not offer enough flexibility
-    # in how to install a package, in which case you can have additional
-    # commands in the install: section below.
-
     - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
-
-    # As described above, using ci-helpers, you should be able to set up an
-    # environment with dependencies installed using conda and pip, but in some
-    # cases this may not provide enough flexibility in how to install a
-    # specific dependency (and it will not be able to install non-Python
-    # dependencies). Therefore, you can also include commands below (as
-    # well as at the start of the install section or in the before_install
-    # section if they are needed before setting up conda) to install any
-    # other dependencies.
+    - source ci-helpers/travis/setup_conda.sh
 
 script:
-   - $MAIN_CMD $SETUP_CMD
+    - $MAIN_CMD $SETUP_CMD
+
+after_success:
+    - if [[ $SETUP_CMD == *--coverage* ]]; then
+        if [ "$TRAVIS_REPO_SLUG" = "astropy/astropy" -o "$TRAVIS_PULL_REQUEST_SLUG" = "astropy/astropy" ]; then
+          cpp-coveralls -E ".*convolution.*" -E ".*_erfa.*" -E ".*\.l" -E ".*\.y" -E ".*flexed.*" -E ".*cextern.*" -E ".*_np_utils.*" -E ".*cparser.*" -E ".*cython_impl.*" --dump c-coveralls.json;
+          coveralls --merge=c-coveralls.json --rcfile='astropy/tests/coveragerc';
+        fi;
+      fi

--- a/drizzle/dodrizzle.py
+++ b/drizzle/dodrizzle.py
@@ -20,18 +20,18 @@ def dodrizzle(insci, input_wcs, inwht,
               pixfrac=1.0, kernel='square', fillval="INDEF"):
     """
     Low level routine for performing 'drizzle' operation.on one image.
-    
+
     The interface is compatible with STScI code. All images are Python
     ndarrays, instead of filenames. File handling (input and output) is
     performed by the calling routine.
-    
+
     Parameters
     ----------
 
     insci : 2d array
         A 2d numpy array containing the input image to be drizzled.
         it is an error to not supply an image.
-    
+
     input_wcs : 2d array
         The world coordinate system of the input image.
 
@@ -39,10 +39,10 @@ def dodrizzle(insci, input_wcs, inwht,
         A 2d numpy array containing the pixel by pixel weighting.
         Must have the same dimensions as insci. If none is supplied,
         the weghting is set to one.
-                
+
     output_wcs : wcs
-        The world coordinate system of the output image. 
-        
+        The world coordinate system of the output image.
+
     outsci : 2d array
         A 2d numpy array containing the output image produced by
         drizzling. On the first call it should be set to zero.
@@ -61,14 +61,14 @@ def dodrizzle(insci, input_wcs, inwht,
     expin : float
         The exposure time of the input image, a positive number. The
         exposure time is used to scale the image if the units are counts.
-            
+
     in_units : str
-        The units of the input image. The units can either be "counts" 
-        or "cps" (counts per second.) 
-        
+        The units of the input image. The units can either be "counts"
+        or "cps" (counts per second.)
+
     wt_scl : float
         A scaling factor applied to the pixel by pixel weighting.
-    
+
     wcslin_pscale : float, optional
         The pixel scale of the input image. Conceptually, this is the
         linear dimension of a side of a pixel in the input image, but it
@@ -88,10 +88,10 @@ def dodrizzle(insci, input_wcs, inwht,
         dimension that varies quickest on the image. If the value is zero,
         no minimum will be set in the x dimension. All four parameters are
         zero based, counting starts at zero.
-        
+
     xmax : float, optional
         Sets the maximum value of the x dimension on the bounding box
-        of the input image. If the value is zero, no maximum will 
+        of the input image. If the value is zero, no maximum will
         be set in the x dimension, the full x dimension of the output
         image is the bounding box.
 
@@ -100,19 +100,19 @@ def dodrizzle(insci, input_wcs, inwht,
         y dimension varies less rapidly than the x and represents the line
         index on the input image. If the value is zero, no minimum  will be
         set in the y dimension.
-        
+
     ymax : float, optional
         Sets the maximum value in the y dimension. If the value is zero, no
         maximum will be set in the y dimension,  the full x dimension
         of the output image is the bounding box.
-            
+
     pixfrac : float, optional
         The fraction of a pixel that the pixel flux is confined to. The
         default value of 1 has the pixel flux evenly spread across the image.
         A value of 0.5 confines it to half a pixel in the linear dimension,
         so the flux is confined to a quarter of the pixel area when the square
-        kernel is used. 
-    
+        kernel is used.
+
     kernel: str, optional
         The name of the kernel used to combine the input. The choice of
         kernel controls the distribution of flux over the kernel. The kernel
@@ -131,8 +131,9 @@ def dodrizzle(insci, input_wcs, inwht,
     output input image.
 
     """
-    
-    # Insure that the fillval parameter gets properly interpreted for use with tdriz
+
+    # Ensure that the fillval parameter gets properly interpreted
+    # for use with tdriz
     if util.is_blank(fillval):
         fillval = 'INDEF'
     else:
@@ -144,13 +145,13 @@ def dodrizzle(insci, input_wcs, inwht,
         expscale = expin
 
     # Add input weight image if it was not passed in
-    
+
     if (insci.dtype > np.float32):
         insci = insci.astype(np.float32)
 
     if inwht is None:
         inwht = np.ones_like(insci)
-    
+
     # Compute what plane of the context image this input would
     # correspond to:
     planeid = int((uniqid-1) / 32)
@@ -162,14 +163,14 @@ def dodrizzle(insci, input_wcs, inwht,
         nplanes = 1
     else:
         nplanes = 0
-        
+
     if nplanes <= planeid:
         raise IndexError("Not enough planes in drizzle context image")
 
     # Alias context image to the requested plane if 3d
     if outcon.ndim == 3:
         outcon = outcon[planeid]
-        
+
     pix_ratio = output_wcs.pscale / wcslin_pscale
 
     # Compute the mapping between the input and output pixel coordinates
@@ -178,12 +179,12 @@ def dodrizzle(insci, input_wcs, inwht,
     #
     # Call 'drizzle' to perform image combination
     # This call to 'cdriz.tdriz' uses the new C syntax
-    # 
+    #
     _vers, nmiss, nskip = cdrizzle.tdriz(
-        insci, inwht, pixmap, outsci, outwht, outcon, 
+        insci, inwht, pixmap, outsci, outwht, outcon,
         uniqid=uniqid, xmin=xmin, xmax=xmax,
         ymin=ymin, ymax=ymax, scale=pix_ratio, pixfrac=pixfrac,
-        kernel=kernel, in_units=in_units, expscale=expscale, 
+        kernel=kernel, in_units=in_units, expscale=expscale,
         wtscale=wt_scl, fillstr=fillval)
 
     return _vers, nmiss, nskip

--- a/drizzle/drizzle.py
+++ b/drizzle/drizzle.py
@@ -28,12 +28,12 @@ class Drizzle(object):
     """
     Combine images using the drizzle algorithm
     """
-    def __init__(self, infile="", outwcs=None,  
-                 wt_scl="exptime", pixfrac=1.0, kernel="square", 
+    def __init__(self, infile="", outwcs=None,
+                 wt_scl="exptime", pixfrac=1.0, kernel="square",
                  fillval="INDEF"):
         """
         Create a new Drizzle output object and set the drizzle parameters.
-        
+
         All parameters are optional, but either infile or outwcs must be supplied.
         If infile initializes the object from a file written after a
         previous run of drizzle. Results from the previous run will be combined
@@ -43,10 +43,10 @@ class Drizzle(object):
         Parameters
         ----------
 
-        infile : str, optional       
+        infile : str, optional
             A fits file containing results from a previous run. The three
             extensions SCI, WHT, and CTX contain the combined image, total counts
-            and image id bitmap, repectively. The WCS of the combined image is 
+            and image id bitmap, repectively. The WCS of the combined image is
             also read from the SCI extension.
 
         outwcs : wcs, optional
@@ -59,14 +59,14 @@ class Drizzle(object):
             which scales each image by its exposure time, `expsq` which scales
             each image by the exposure time squared, or an empty string, which
             allows each input image to be scaled individually.
-            
+
         pixfrac : float, optional
             The fraction of a pixel that the pixel flux is confined to. The
             default value of 1 has the pixel flux evenly spread across the image.
             A value of 0.5 confines it to half a pixel in the linear dimension,
             so the flux is confined to a quarter of the pixel area when the square
-            kernel is used. 
-        
+            kernel is used.
+
         kernel : str, optional
             The name of the kernel used to combine the inputs. The choice of
             kernel controls the distribution of flux over the kernel. The kernel
@@ -92,7 +92,7 @@ class Drizzle(object):
         self.kernel = kernel
         self.fillval = fillval
         self.pixfrac = float(pixfrac)
-        
+
         self.sciext = "SCI"
         self.whtext = "WHT"
         self.ctxext = "CTX"
@@ -110,7 +110,7 @@ class Drizzle(object):
                 self.sciext = util.get_keyword(handle, "DRIZOUDA", default="SCI")
                 self.whtext = util.get_keyword(handle, "DRIZOUWE", default="WHT")
                 self.ctxext = util.get_keyword(handle, "DRIZOUCO", default="CTX")
-                
+
                 self.wt_scl = util.get_keyword(handle, "DRIZWTSC", default=wt_scl)
                 self.kernel = util.get_keyword(handle, "DRIZKERN", default=kernel)
                 self.fillval = util.get_keyword(handle, "DRIZFVAL", default=fillval)
@@ -125,18 +125,18 @@ class Drizzle(object):
                     self.outwcs = wcs.WCS(hdu.header, fobj=handle)
                 except KeyError:
                     pass
-                
+
                 try:
                     hdu = handle[self.whtext]
                     self.outwht = hdu.data.copy().astype(np.float32)
                 except KeyError:
                     pass
-                
+
                 try:
                     hdu = handle[self.ctxext]
                     self.outcon = hdu.data.copy().astype(np.int32)
                     if self.outcon.ndim == 2:
-                        self.outcon = np.reshape(self.outcon, (1, 
+                        self.outcon = np.reshape(self.outcon, (1,
                                                  self.outcon.shape[0],
                                                  self.outcon.shape[1]))
 
@@ -147,14 +147,14 @@ class Drizzle(object):
                         msg = ("Drizzle context image has wrong dimensions: " +
                                infile)
                         raise ValueError(msg)
-                        
+
                 except KeyError:
                     pass
 
                 handle.close()
 
         # Check field values
-    
+
         if self.outwcs:
             util.set_pscale(self.outwcs)
         else:
@@ -164,7 +164,7 @@ class Drizzle(object):
             self.wt_scl = ''
         elif self.wt_scl != "exptime" and self.wt_scl != "expsq":
             raise ValueError("Illegal value for wt_scl: %s" % out_units)
-        
+
         if out_units == "counts":
             np.divide(self.outsci, self.outexptime, self.outsci)
         elif out_units != "cps":
@@ -192,19 +192,19 @@ class Drizzle(object):
                       xmin=0, xmax=0, ymin=0, ymax=0,
                       unitkey="", expkey="", wt_scl=1.0):
         """
-        Combine a fits file with the output drizzled image. 
-        
+        Combine a fits file with the output drizzled image.
+
         Parameters
         ----------
 
         infile : str
             The name of the fits file, possibly including an extension.
-        
+
         inweight : str, otional
             The name of a file containing a pixel by pixel weighting
             of the input data. If it is not set, an array will be generated
             where all values are set to one.
-            
+
         xmin : float, otional
             This and the following three parameters set a bounding rectangle
             on the output image. Only pixels on the output image inside this
@@ -213,36 +213,36 @@ class Drizzle(object):
             quickest on the image. If the value is zero or less, no minimum will
             be set in the x dimension. All four parameters are zero based,
             counting starts at zero.
-            
+
         xmax : float, otional
             Sets the maximum value of the x dimension on the bounding box
-            of the ouput image. If the value is zero or less, no maximum will 
+            of the ouput image. If the value is zero or less, no maximum will
             be set in the x dimension.
 
         ymin : float, optional
             Sets the minimum value in the y dimension on the bounding box. The
             y dimension varies less rapidly than the x and represents the line
-            index on the output image. If the value is zero or less, no minimum 
+            index on the output image. If the value is zero or less, no minimum
             will be set in the y dimension.
-            
+
         ymax : float, optional
             Sets the maximum value in the y dimension. If the value is zero or
             less, no maximum will be set in the y dimension.
-            
+
         unitkey : string, optional
-            The name of the header keyword containing the image units. The 
-            units can either be "counts" or "cps" (counts per second.) If it is 
-            left blank, the value is assumed to be "cps." If the value is counts, 
+            The name of the header keyword containing the image units. The
+            units can either be "counts" or "cps" (counts per second.) If it is
+            left blank, the value is assumed to be "cps." If the value is counts,
             before using the input image it is scaled by dividing it by the
             exposure time.
-            
+
         expkey : string, optional
             The name of the header keyword containing the exposure time. The
             exposure time is used to scale the image if the units are counts and
             to scale the image weighting if the drizzle was initialized with
             wt_scl equal to "exptime" or "expsq." If the value of this parameter
             is blank, the exposure time is set to one, implying no scaling.
-            
+
         wt_scl : float, optional
             If drizzle was initialized with wt_scl left blank, this value will
             set a scaling factor for the pixel weighting. If drizzle was
@@ -260,7 +260,7 @@ class Drizzle(object):
             if os.path.exists(fileroot):
                 handle = fits.open(fileroot)
                 hdu = util.get_extn(handle, extn=extn)
-    
+
                 if hdu is not None:
                     insci = hdu.data
                     inwcs = wcs.WCS(header=hdu.header)
@@ -276,45 +276,45 @@ class Drizzle(object):
             if os.path.exists(fileroot):
                 handle = fits.open(fileroot)
                 hdu = util.get_extn(handle, extn=extn)
-    
+
                 if hdu is not None:
                     inwht = hdu.data.copy()
                 handle.close()
 
         in_units = util.get_keyword(fileroot, unitkey, "cps")
         expin = util.get_keyword(fileroot, expkey, 1.0)
-       
-        self.add_image(insci, inwcs, inwht=inwht, 
+
+        self.add_image(insci, inwcs, inwht=inwht,
                        xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax,
                        expin=expin, in_units=in_units, wt_scl=wt_scl)
 
 
-    def add_image(self, insci, inwcs, inwht=None, 
+    def add_image(self, insci, inwcs, inwht=None,
                   xmin=0, xmax=0, ymin=0, ymax=0,
                   expin=1.0, in_units="cps", wt_scl=1.0):
         """
         Combine an input image with the output drizzled image.
-        
+
         Instead of reading the parameters from a fits file, you can set
         them by calling this lower level method. `Add_fits_file` calls
         this method after doing its setup.
-        
+
         Parameters
         ----------
 
         insci : array
             A 2d numpy array containing the input image to be drizzled.
             it is an error to not supply an image.
-        
+
         inwcs : wcs
             The world coordinate system of the input image. This is
             used to convert the pixels to the output coordinate system.
-            
+
         inwht : array, optional
             A 2d numpy array containing the pixel by pixel weighting.
             Must have the same dimenstions as insci. If none is supplied,
             the weghting is set to one.
-            
+
         xmin : float, optional
             This and the following three parameters set a bounding rectangle
             on the output image. Only pixels on the output image inside this
@@ -323,22 +323,22 @@ class Drizzle(object):
             quickest on the image. If the value is zero or less, no minimum will
             be set in the x dimension. All four parameters are zero based,
             counting starts at zero.
-            
+
         xmax : float, optional
             Sets the maximum value of the x dimension on the bounding box
-            of the ouput image. If the value is zero or less, no maximum will 
+            of the ouput image. If the value is zero or less, no maximum will
             be set in the x dimension.
 
         ymin : float, optional
             Sets the minimum value in the y dimension on the bounding box. The
             y dimension varies less rapidly than the x and represents the line
-            index on the output image. If the value is zero or less, no minimum 
+            index on the output image. If the value is zero or less, no minimum
             will be set in the y dimension.
-            
+
         ymax : float, optional
             Sets the maximum value in the y dimension. If the value is zero or
             less, no maximum will be set in the y dimension.
-            
+
         expin : float, optional
             The exposure time of the input image, a positive number. The
             exposure time is used to scale the image if the units are counts and
@@ -346,10 +346,10 @@ class Drizzle(object):
             wt_scl equal to "exptime" or "expsq."
 
         in_units : str, optional
-            The units of the input image. The units can either be "counts" 
+            The units of the input image. The units can either be "counts"
             or "cps" (counts per second.) If the value is counts, before using
             the input image it is scaled by dividing it by the exposure time.
-            
+
         wt_scl : float, optional
             If drizzle was initialized with wt_scl left blank, this value will
             set a scaling factor for the pixel weighting. If drizzle was
@@ -365,7 +365,7 @@ class Drizzle(object):
             inwht = np.ones(insci.shape, dtype=insci.dtype)
         else:
             inwht = inwht.astype(np.float32)
-        
+
         if self.wt_scl == "exptime":
             wt_scl = expin
         elif self.wt_scl == "expsq":
@@ -373,20 +373,20 @@ class Drizzle(object):
 
         self.increment_id()
         self.outexptime += expin
-        
-        dodrizzle.dodrizzle(insci, inwcs, inwht, self.outwcs, 
+
+        dodrizzle.dodrizzle(insci, inwcs, inwht, self.outwcs,
                             self.outsci, self.outwht, self.outcon,
                             expin, in_units, wt_scl,
                             wcslin_pscale=inwcs.pscale, uniqid=self.uniqid,
-                            xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax, 
+                            xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax,
                             pixfrac=self.pixfrac, kernel=self.kernel,
                             fillval=self.fillval)
 
-        
+
     def blot_fits_file(self, infile, interp='poly5', sinscl=1.0):
         """
         Resample the output using another image's world coordinate system.
-        
+
         Parameters
         ----------
 
@@ -394,7 +394,7 @@ class Drizzle(object):
             The name of the fits file containing the world coordinate
             system that the output file will be resampled to. The name may
             possibly include an extension.
-            
+
         interp : str, optional
             The type of interpolation used in the resampling. The
             possible values are "nearest" (nearest neighbor interpolation),
@@ -402,7 +402,7 @@ class Drizzle(object):
             interpolation), "poly5" (quintic polynomial interpolation),
             "sinc" (sinc interpolation), "lan3" (3rd order Lanczos
             interpolation), and "lan5" (5th order Lanczos interpolation).
-            
+
         sincscl : float, optional
             The scaling factor for sinc interpolation.
         """
@@ -422,11 +422,11 @@ class Drizzle(object):
             raise ValueError("Drizzle did not get a blot reference image")
 
         self.blot_image(blotwcs, interp=interp, sinscl=sinscl)
-    
+
     def blot_image(self, blotwcs, interp='poly5', sinscl=1.0):
         """
         Resample the output image using an input world coordinate system.
-        
+
         Parameters
         ----------
 
@@ -440,22 +440,22 @@ class Drizzle(object):
             interpolation), "poly5" (quintic polynomial interpolation),
             "sinc" (sinc interpolation), "lan3" (3rd order Lanczos
             interpolation), and "lan5" (5th order Lanczos interpolation).
-            
+
         sincscl : float, optional
             The scaling factor for sinc interpolation.
         """
 
         util.set_pscale(blotwcs)
-        self.outsci = doblot.doblot(self.outsci, self.outwcs, blotwcs, 
+        self.outsci = doblot.doblot(self.outsci, self.outwcs, blotwcs,
                                     1.0, interp=interp, sinscl=sinscl)
 
         self.outwcs = blotwcs
-        
+
 
     def increment_id(self):
         """
         Increment the id count and add a plane to the context image if needed
-        
+
         Drizzle tracks which input images contribute to the output image
         by setting a bit in the corresponding pixel in the context image.
         The uniqid indicates which bit. So it must be incremented each time
@@ -468,7 +468,7 @@ class Drizzle(object):
         planeid = int(self.uniqid / 32)
 
         # Add a new plane to the context image if planeid overflows
-        
+
         if self.outcon.shape[0] == planeid:
             plane = np.zeros_like(self.outcon[0])
             self.outcon = np.append(self.outcon, plane, axis=0)
@@ -480,7 +480,7 @@ class Drizzle(object):
     def write(self, outfile, out_units="cps", outheader=None):
         """
         Write the output from a set of drizzled images to a file.
-        
+
         The output file will contain three extensions. The "SCI" extension
         contains the resulting image. The "WHT" extension contains the
         combined weights. The "CTX" extension is a bit map. The nth bit
@@ -488,7 +488,7 @@ class Drizzle(object):
         to the output image. The "CTX" image is three dimensionsional
         to account for the possibility that there are more than 32 input
         images.
-        
+
         Parameters
         ----------
 
@@ -500,7 +500,7 @@ class Drizzle(object):
             The units of the output image, either `counts` or `cps`
             (counts per second.) If the units are counts, the resulting
             image will be multiplied by the computed exposure time.
-        
+
         outheader : header, optional
             A fits header containing cards to be added to the primary
             header of the output image.
@@ -510,11 +510,11 @@ class Drizzle(object):
             raise ValueError("Illegal value for out_units: %s" % str(out_units))
 
         # Write the WCS to the output image
-        
+
         handle = self.outwcs.to_fits()
         phdu = handle[0]
-        
-        # Write the class fields to the primary header 
+
+        # Write the class fields to the primary header
         phdu.header['DRIZOUDA'] = \
             (self.sciext, 'Drizzle, output data image')
         phdu.header['DRIZOUWE'] = \
@@ -526,7 +526,7 @@ class Drizzle(object):
         phdu.header['DRIZKERN'] = \
             (self.kernel, 'Drizzle, form of weight distribution kernel')
         phdu.header['DRIZPIXF'] = \
-            (self.pixfrac, 'Drizzle, linear size of drop') 
+            (self.pixfrac, 'Drizzle, linear size of drop')
         phdu.header['DRIZFVAL'] = \
             (self.fillval, 'Drizzle, fill value for zero weight output pix')
         phdu.header['DRIZOUUN'] = \
@@ -543,7 +543,7 @@ class Drizzle(object):
 
         phdu.header['EXPTIME'] = \
             (self.outexptime, 'Drizzle, total exposure time')
-        
+
         outexptime = 1.0
         if out_units == 'counts':
             np.multiply(self.outsci, self.outexptime, self.outsci)
@@ -552,13 +552,13 @@ class Drizzle(object):
         (outexptime, 'Drizzle, exposure time scaling factor')
 
         # Copy the optional header to the primary header
-        
+
         if outheader:
             phdu.header.extend(outheader, unique=True)
 
         # Add three extensions containing, the drizzled output image,
         # the total counts, and the context bitmap, in that order
-        
+
         extheader = self.outwcs.to_header()
 
         ehdu = fits.ImageHDU()
@@ -567,14 +567,14 @@ class Drizzle(object):
         ehdu.header['EXTVER'] = (1, 'Extension version')
         ehdu.header.extend(extheader, unique=True)
         handle.append(ehdu)
-        
+
         whdu = fits.ImageHDU()
         whdu.data = self.outwht
         whdu.header['EXTNAME'] = (self.whtext, 'Extension name')
         whdu.header['EXTVER'] = (1, 'Extension version')
         whdu.header.extend(extheader, unique=True)
         handle.append(whdu)
-            
+
         xhdu = fits.ImageHDU()
         xhdu.data = self.outcon
         xhdu.header['EXTNAME'] = (self.ctxext, 'Extension name')
@@ -582,5 +582,5 @@ class Drizzle(object):
         xhdu.header.extend(extheader, unique=True)
         handle.append(xhdu)
 
-        handle.writeto(outfile, clobber=True)
+        handle.writeto(outfile, overwrite=True)
         handle.close()

--- a/drizzle/tests/test_file_io.py
+++ b/drizzle/tests/test_file_io.py
@@ -70,9 +70,9 @@ def test_null_run():
     output_wcs = read_wcs(output_template)
     driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="expsq",
                                    pixfrac=0.5, kernel="turbo",
-                                   fillval="999.")
+                                   fillval="NaN")
     driz.write(output_file)
-    
+
     assert(os.path.exists(output_file))
     handle = fits.open(output_file)
 
@@ -87,7 +87,7 @@ def test_null_run():
     assert(pheader['DRIZWTSC'] == 'expsq')
     assert(pheader['DRIZKERN'] == 'turbo')
     assert(pheader['DRIZPIXF'] == 0.5)
-    assert(pheader['DRIZFVAL'] == '999.')
+    assert(pheader['DRIZFVAL'] == 'NaN')
     assert(pheader['DRIZOUUN'] == 'cps')
     assert(pheader['EXPTIME'] == 0.0)
     assert(pheader['DRIZEXPT'] == 1.0)
@@ -106,13 +106,13 @@ def test_file_init():
     assert(driz.wt_scl == 'expsq')
     assert(driz.kernel == 'turbo')
     assert(driz.pixfrac == 0.5)
-    assert(driz.fillval == '999.')
+    assert(driz.fillval == 'NaN')
 
 def test_add_header():
     """
     Add extra keywords read from the header
     """
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')        
+    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
     output_file = os.path.join(OUTPUT_DIR, 'output_add_header.fits')
     output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
 
@@ -126,7 +126,7 @@ def test_add_header():
     header['TWOVAL'] = (2.0, 'test value')
 
     driz.write(output_file, outheader=header)
-    
+
     header = read_header(output_file)
     assert(header['ONEVAL'] == 1.0)
     assert(header['TWOVAL'] == 2.0)
@@ -136,7 +136,7 @@ def test_add_file():
     """
     Add an image read from a file
     """
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits[1]')        
+    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits[1]')
     output_file = os.path.join(OUTPUT_DIR, 'output_add_file.fits')
     test_file = os.path.join(OUTPUT_DIR, 'output_add_header.fits')
     output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
@@ -165,7 +165,7 @@ def test_blot_file():
     driz.add_fits_file(input_file)
     driz.blot_image(blotwcs)
     driz.write(test_file)
-    
+
     driz = drizzle.Drizzle(infile=output_template)
     driz.add_fits_file(input_file)
     driz.blot_fits_file(input_file)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.11'
+VERSION = '1.12'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
The drizzle user has the option of setting unwritten pixels in the output image to a fill value rather than the default value of zero. This value is set by the drizzle parameter fillstr. If this parameter is "NaN" or "nan" the fill value in the output image will be "Not a Number."