### PR TITLE
Quick fix for drizzle cases with negative values in the pixmap transformation

### DIFF
--- a/drizzle/calc_pixmap.py
+++ b/drizzle/calc_pixmap.py
@@ -36,17 +36,22 @@ def calc_pixmap(first_wcs, second_wcs):
     # co-ordinate system of the second.
 
     one = np.ones(2, dtype='float64')
+    ix = 1
+    
+    # one = np.zeros(2, dtype='float64')
+    # ix = 0
+    
     idxmap = np.indices((first_naxis1, first_naxis2), dtype='float64')
-    idxmap = idxmap.transpose() + one
+    idxmap = idxmap.transpose() + one 
     
     idxmap = idxmap.reshape(first_naxis2 * first_naxis1, 2)
         
-    worldmap = first_wcs.all_pix2world(idxmap, 1)
+    worldmap = first_wcs.all_pix2world(idxmap, ix)
 
     if second_wcs.sip is None:
-        pixmap = second_wcs.wcs_world2pix(worldmap, 1)
+        pixmap = second_wcs.wcs_world2pix(worldmap, ix)
     else:
-        pixmap = second_wcs.all_world2pix(worldmap, 1)
+        pixmap = second_wcs.all_world2pix(worldmap, ix)
 
     pixmap = pixmap.reshape(first_naxis2, first_naxis1, 2)
     pixmap = pixmap - one

--- a/drizzle/dodrizzle.py
+++ b/drizzle/dodrizzle.py
@@ -175,33 +175,7 @@ def dodrizzle(insci, input_wcs, inwht,
 
     # Compute the mapping between the input and output pixel coordinates
     pixmap = calc_pixmap.calc_pixmap(input_wcs, output_wcs)
-    
-    # Add additional clipping for negative pixmap values
-    # This should be done rather in tdriz, but this is a quick pure-python fix
-    if pixmap.min() < 0:
-        mask = pixmap > 0
-        
-        insh = insci.shape
-        yp, xp = np.indices(insh)
-        xmi = xp[mask[:,:,0]].min()
-        xma = xp[mask[:,:,0]].max()
-        ymi = yp[mask[:,:,1]].min()
-        yma = yp[mask[:,:,1]].max()
-
-        xmin = np.maximum(xmin, xmi)
-        if xmax == 0:
-            xmax = xma
-        else:
-            xmax = np.minimum(xmax, xma)
-        
-        ymin = np.maximum(ymin, ymi)
-        if ymax == 0:
-            ymax = yma
-        else:
-            ymax = np.minimum(ymax, xma)
-        
-        #print('xxx clip pixmap!', xmin, xmax, ymin, ymax)
-        
+            
     #
     # Call 'drizzle' to perform image combination
     # This call to 'cdriz.tdriz' uses the new C syntax

--- a/drizzle/dodrizzle.py
+++ b/drizzle/dodrizzle.py
@@ -179,7 +179,6 @@ def dodrizzle(insci, input_wcs, inwht,
     # Add additional clipping for negative pixmap values
     # This should be done rather in tdriz, but this is a quick pure-python fix
     if pixmap.min() < 0:
-        #print('xxx clip pixmap!')
         mask = pixmap > 0
         
         insh = insci.shape
@@ -190,10 +189,19 @@ def dodrizzle(insci, input_wcs, inwht,
         yma = yp[mask[:,:,1]].max()
 
         xmin = np.maximum(xmin, xmi)
-        xmax = np.minimum(xmax, xma)
+        if xmax == 0:
+            xmax = xma
+        else:
+            xmax = np.minimum(xmax, xma)
+        
         ymin = np.maximum(ymin, ymi)
-        ymax = np.minimum(ymax, yma)      
-          
+        if ymax == 0:
+            ymax = yma
+        else:
+            ymax = np.minimum(ymax, xma)
+        
+        #print('xxx clip pixmap!', xmin, xmax, ymin, ymax)
+        
     #
     # Call 'drizzle' to perform image combination
     # This call to 'cdriz.tdriz' uses the new C syntax

--- a/drizzle/dodrizzle.py
+++ b/drizzle/dodrizzle.py
@@ -175,7 +175,25 @@ def dodrizzle(insci, input_wcs, inwht,
 
     # Compute the mapping between the input and output pixel coordinates
     pixmap = calc_pixmap.calc_pixmap(input_wcs, output_wcs)
+    
+    # Add additional clipping for negative pixmap values
+    # This should be done rather in tdriz, but this is a quick pure-python fix
+    if pixmap.min() < 0:
+        print('xxx clip pixmap!')
+        mask = pixmap > 0
+        
+        insh = insci.shape
+        yp, xp = np.indices(insh)
+        xmi = xp[mask[:,:,0]].min()
+        xma = xp[mask[:,:,0]].max()
+        ymi = yp[mask[:,:,1]].min()
+        yma = yp[mask[:,:,1]].max()
 
+        xmin = np.maximum(xmin, xmi)
+        xmax = np.minimum(xmax, xma)
+        ymin = np.maximum(ymin, ymi)
+        ymax = np.minimum(ymax, yma)      
+          
     #
     # Call 'drizzle' to perform image combination
     # This call to 'cdriz.tdriz' uses the new C syntax

--- a/drizzle/dodrizzle.py
+++ b/drizzle/dodrizzle.py
@@ -179,7 +179,7 @@ def dodrizzle(insci, input_wcs, inwht,
     # Add additional clipping for negative pixmap values
     # This should be done rather in tdriz, but this is a quick pure-python fix
     if pixmap.min() < 0:
-        print('xxx clip pixmap!')
+        #print('xxx clip pixmap!')
         mask = pixmap > 0
         
         insh = insci.shape

--- a/drizzle/src/cdrizzlemap.c
+++ b/drizzle/src/cdrizzlemap.c
@@ -109,6 +109,9 @@ shrink_segment(struct segment *self,
   imin = self->point[1][0];
   jmin = self->point[1][1];
   
+  imin = 65000; 
+  jmin = 65000;
+  
   for (j = self->point[0][1]; j < self->point[1][1]; ++j) {
     for (i = self->point[0][0]; i < self->point[1][0]; ++ i) {
       if (! is_bad_value(array, i, j)) {
@@ -119,13 +122,17 @@ shrink_segment(struct segment *self,
           jmin = j;
         }
         break;
+      } else {
+          // printf('pixel is bad %d %d', i, j);
       }
     }
   }
   
   imax = self->point[0][0];
   jmax = self->point[0][1];
-
+  
+  imax = -1;
+  jmax = -1;
   for (j = self->point[1][1]; j > self->point[0][1]; --j) {  
     for (i = self->point[1][0]; i > self->point[0][0]; -- i) {
       if (! is_bad_value(array, i-1, j-1)) {
@@ -139,6 +146,7 @@ shrink_segment(struct segment *self,
       }
     }
   }
+  // printf("segment %d %d %d %d\n", imin, imax, jmin, jmax);
   
   initialize_segment(self, imin, jmin, imax, jmax);
   self->invalid = imin >= imax || jmin >= jmax;
@@ -576,10 +584,10 @@ check_line_overlap(struct driz_param_t* p, int margin, integer_t j, integer_t *x
   initialize_segment(&xybounds, p->xmin, j, p->xmax, j+1);
   shrink_segment(&xybounds, p->pixmap, &bad_pixel);
   
-  if (clip_bounds(p->pixmap, &outlimit, &xybounds)) {
-    driz_error_set_message(p->error, "cannot compute xbounds");
-    return 1;
-  }
+  // if (clip_bounds(p->pixmap, &outlimit, &xybounds)) {
+  //   driz_error_set_message(p->error, "cannot compute xbounds");
+  //   return 1;
+  // }
 
   sort_segment(&xybounds, 0);
   shrink_segment(&xybounds, p->weights, &bad_weight);
@@ -619,7 +627,7 @@ check_image_overlap(struct driz_param_t* p, const int margin, integer_t *ybounds
                      osize[0] + margin, osize[1] + margin);
 
   initialize_segment(&inlimit, p->xmin, p->ymin, p->xmax, p->ymax);
-  shrink_segment(&inlimit, p->pixmap, &bad_pixel);
+  //shrink_segment(&inlimit, p->pixmap, &bad_pixel);
   
   if (inlimit.invalid == 1) {
       driz_error_set_message(p->error, "no valid pixels on input image");
@@ -631,10 +639,10 @@ check_image_overlap(struct driz_param_t* p, const int margin, integer_t *ybounds
                        inlimit.point[ipoint][0], inlimit.point[0][1],
                        inlimit.point[ipoint][0], inlimit.point[1][1]);
 
-    if (clip_bounds(p->pixmap, &outlimit, &xybounds[ipoint])) {
-      driz_error_set_message(p->error, "cannot compute ybounds");
-      return 1;
-    }
+    // if (clip_bounds(p->pixmap, &outlimit, &xybounds[ipoint])) {
+    //   driz_error_set_message(p->error, "cannot compute ybounds");
+    //   return 1;
+    // }
   }
 
   union_of_segments(2, 1, xybounds, ybounds);

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ LONG_DESCRIPTION = package.__doc__
 builtins._ASTROPY_PACKAGE_NAME_ = PACKAGENAME
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '1.12'
+VERSION = '1.12.99'
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
I discovered some problematic behavior when trying to use `drizzle` to map to an output wcs that is contained within the input wcs, where the result was an empty image.  That was a symptom, for which I think the more general cause is that the `pixmap` computed by `drizzle.calc_pixmap.calc_pixmap(input_wcs, output_wcs)` has negative values that trip pixel range checks within the `tdriz` C code, which then faults out without doing anything.

This would be fixed by specifying xmin/xmax/ymin/ymax values at runtime with `drizzle.dodrizzle`, but it would preferable to make the desired behavior more transparent by default.  This PR computes updates to xmin/xmax/ymin/ymax for cases where the derived `pixmap` has negative values.  I think ideally the fix would be implemented within the `tdriz` C code, since the fix here could result in expensive tests on large index matrices in cases of large input image dimensions.