### PR TITLE
Remove use of deprecated astropy.WCS _naxis1 & _naxis2

### DIFF
--- a/drizzle/calc_pixmap.py
+++ b/drizzle/calc_pixmap.py
@@ -26,8 +26,7 @@ def calc_pixmap(first_wcs, second_wcs):
     correspond to the two coordinates of the image the first WCS is from.
     """
 
-    first_naxis1 = first_wcs._naxis1
-    first_naxis2 = first_wcs._naxis2
+    first_naxis1, first_naxis2 = first_wcs.pixel_shape
 
     # We add one to the pixel co-ordinates before the transformation and subtract
     # it afterwards because wcs co-ordinates are one based, while pixel co-ordinates

--- a/drizzle/doblot.py
+++ b/drizzle/doblot.py
@@ -69,7 +69,7 @@ def doblot(source, source_wcs, blot_wcs, exptime, coeffs = True,
         Was used when input to output mapping was computed
         internally. Is no longer used and only here for backwards compatibility.
     """
-    _outsci = np.zeros(blot_wcs.pixel_shape[::-1],dtype=np.float32)
+    _outsci = np.zeros(blot_wcs.pixel_shape[::-1], dtype=np.float32)
 
     # compute the undistorted 'natural' plate scale 
     wcslin = blot_wcs

--- a/drizzle/doblot.py
+++ b/drizzle/doblot.py
@@ -69,7 +69,7 @@ def doblot(source, source_wcs, blot_wcs, exptime, coeffs = True,
         Was used when input to output mapping was computed
         internally. Is no longer used and only here for backwards compatibility.
     """
-    _outsci = np.zeros((blot_wcs._naxis2,blot_wcs._naxis1),dtype=np.float32)
+    _outsci = np.zeros(blot_wcs.pixel_shape[::-1],dtype=np.float32)
 
     # compute the undistorted 'natural' plate scale 
     wcslin = blot_wcs

--- a/drizzle/drizzle.py
+++ b/drizzle/drizzle.py
@@ -171,20 +171,18 @@ class Drizzle(object):
             raise ValueError("Illegal value for wt_scl: %s" % out_units)
 
         # Initialize images if not read from a file
-
+        outwcs_naxis1, outwcs_naxis2 = self.outwcs.pixel_shape
         if self.outsci is None:
-            self.outsci = np.zeros((self.outwcs._naxis2,
-                                   self.outwcs._naxis1),
+            self.outsci = np.zeros(self.outwcs.pixel_shape[::-1],
                                    dtype=np.float32)
 
         if self.outwht is None:
-            self.outwht = np.zeros((self.outwcs._naxis2,
-                                    self.outwcs._naxis1),
-                                    dtype=np.float32)
+            self.outwht = np.zeros(self.outwcs.pixel_shape[::-1],
+                                   dtype=np.float32)
         if self.outcon is None:
             self.outcon = np.zeros((1,
-                                    self.outwcs._naxis2,
-                                    self.outwcs._naxis1),
+                                    outwcs_naxis2,
+                                    outwcs_naxis1),
                                     dtype=np.int32)
 
 

--- a/drizzle/tests/test_pixmap.py
+++ b/drizzle/tests/test_pixmap.py
@@ -34,8 +34,7 @@ def test_map_to_self():
     input_shape = input_hdu[1].data.shape
 
     input_wcs = wcs.WCS(input_hdu[1].header)
-    naxis1 = input_wcs._naxis1
-    naxis2 = input_wcs._naxis2
+    naxis1, naxis2 = input_wcs.pixel_shape
     input_hdu.close()
 
     ok_pixmap = np.indices((naxis1, naxis2), dtype='float32')
@@ -54,8 +53,7 @@ def test_translated_map():
     first_header = first_hdu[1].header
     
     first_wcs = wcs.WCS(first_header)
-    naxis1 = first_wcs._naxis1
-    naxis2 = first_wcs._naxis2
+    naxis1, naxis2 = first_wcs.pixel_shape
     first_hdu.close()
 
     second_file = os.path.join(DATA_DIR, 'input3.fits')


### PR DESCRIPTION
This is a propagation of https://github.com/astropy/astropy/pull/7973

This would tether Drizzle to Astropy >=3.1.

Signed-off-by: James Noss <jnoss@stsci.edu>