### PR TITLE
Remove use of deprecated np.matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ __pycache__
 */cython_version.py
 htmlcov
 MANIFEST
-.coverage
+.coverage*
 docs/api/
 
 # Test output

--- a/drizzle/tests/test_cdrizzle.py
+++ b/drizzle/tests/test_cdrizzle.py
@@ -1,9 +1,7 @@
-from __future__ import print_function, absolute_import
-
 import numpy as np
 
-from .. import drizzle
-from .. import cdrizzle
+from drizzle import drizzle
+from drizzle import cdrizzle
 
 def test_cdrizzle():
     """
@@ -24,6 +22,3 @@ def test_cdrizzle():
     cdrizzle.test_cdrizzle(data, weights, pixmap,
                            output_data, output_counts,
                            output_context)
-
-if __name__ == "__main__":
-    test_cdrizzle()

--- a/drizzle/tests/test_drizzle.py
+++ b/drizzle/tests/test_drizzle.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, unicode_literals, absolute_import
-
 import sys
 import math
 import os
@@ -14,6 +12,8 @@ import numpy.testing as npt
 from astropy import wcs
 from astropy.io import fits
 
+from drizzle import drizzle
+
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
 OUTPUT_DIR = os.environ.get('DRIZZLE_TEST_OUTPUT_DIR', tempfile.mkdtemp())
@@ -23,8 +23,6 @@ def output_dir():
     yield
     if 'DRIZZLE_TEST_OUTPUT_DIR' not in os.environ:
         shutil.rmtree(OUTPUT_DIR)
-
-from .. import drizzle
 
 ok = False
 

--- a/drizzle/tests/test_file_io.py
+++ b/drizzle/tests/test_file_io.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, unicode_literals, absolute_import
-
 import sys
 import glob
 import math
@@ -14,6 +12,9 @@ import numpy.testing as npt
 from astropy import wcs
 from astropy.io import fits
 
+from drizzle import drizzle
+from drizzle import util
+
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
 OUTPUT_DIR = os.environ.get('DRIZZLE_TEST_OUTPUT_DIR', tempfile.mkdtemp())
@@ -23,9 +24,6 @@ def output_dir():
     yield
     if 'DRIZZLE_TEST_OUTPUT_DIR' not in os.environ:
         shutil.rmtree(OUTPUT_DIR)
-
-from .. import drizzle
-from .. import util
 
 def read_header(filename):
     """

--- a/drizzle/tests/test_pixmap.py
+++ b/drizzle/tests/test_pixmap.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import
-
 import sys
 import os.path
 import numpy as np
@@ -8,10 +6,10 @@ import numpy.testing as npt
 from astropy import wcs
 from astropy.io import fits
 
+from drizzle import calc_pixmap
+
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
-
-from .. import calc_pixmap
 
 def test_map_rectangular():
     """

--- a/drizzle/util.py
+++ b/drizzle/util.py
@@ -238,18 +238,18 @@ def set_pscale(the_wcs):
         A WCS object
     """
     try:
-        cdelt = np.matrix(np.diag(the_wcs.wcs.get_cdelt()))
-        pc = np.matrix(the_wcs.wcs.get_pc())
+        cdelt = the_wcs.wcs.get_cdelt()
+        pc = the_wcs.wcs.get_pc()
 
     except InconsistentAxisTypesError:
         try:
             # for non-celestial axes, get_cdelt doesnt work
-            cdelt = np.matrix(the_wcs.wcs.cd) * np.matrix(np.diag(the_wcs.wcs.cdelt))
+            cdelt = the_wcs.wcs.cd @ the_wcs.wcs.cdelt
         except AttributeError:
-            cdelt = np.matrix(np.diag(the_wcs.wcs.cdelt))
+            cdelt = the_wcs.wcs.cdelt
 
         try:
-            pc = np.matrix(the_wcs.wcs.pc)
+            pc = the_wcs.wcs.pc
         except AttributeError:
             pc = 1
 

--- a/drizzle/util.py
+++ b/drizzle/util.py
@@ -241,10 +241,10 @@ def set_pscale(the_wcs):
         cdelt = the_wcs.wcs.get_cdelt()
         pc = the_wcs.wcs.get_pc()
 
-    except InconsistentAxisTypesError:
+    except Exception:
         try:
             # for non-celestial axes, get_cdelt doesnt work
-            cdelt = the_wcs.wcs.cd @ the_wcs.wcs.cdelt
+            cdelt = the_wcs.wcs.cd * the_wcs.wcs.cdelt
         except AttributeError:
             cdelt = the_wcs.wcs.cdelt
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ show-response = 1
 
 [tool:pytest]
 minversion = 3.0
-norecursedirs = build docs/_build
+norecursedirs = build docs/_build astropy_helpers
 doctest_plus = enabled
 
 [ah_bootstrap]


### PR DESCRIPTION
Fixes the following deprecation of `np.matrix`:
```
drizzle/drizzle/util.py:242: PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
    pc = np.matrix(the_wcs.wcs.get_pc())
```