### PR TITLE
Use oldest-supported-numpy in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "numpy", "setuptools_scm[toml]>=3.4"]
+requires = [
+    "setuptools>=42",
+    "setuptools_scm[toml]>=3.4",
+    "wheel",
+    "oldest-supported-numpy",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,6 @@ select =
     E722
 
 [tool:pytest]
-minversion = 3.0
-norecursedirs = .eggs build docs/_build
+minversion = 4.6
+norecursedirs = build docs/_build
 doctest_plus = enabled

--- a/setup.py
+++ b/setup.py
@@ -9,29 +9,24 @@ import numpy
 
 
 def get_extensions():
-    ROOT = os.path.dirname(__file__)
-    SRCDIR = os.path.join(ROOT, 'src')
-    cfg = {
-        'include_dirs': [],
-        'libraries': [],
-        'define_macros': []
-    }
-
+    srcdir = os.path.join(os.path.dirname(__file__), 'src')
     cdriz_sources = ['cdrizzleapi.c',
                      'cdrizzleblot.c',
                      'cdrizzlebox.c',
                      'cdrizzlemap.c',
                      'cdrizzleutil.c',
                      os.path.join('tests', 'utest_cdrizzle.c')]
+    sources = [os.path.join(srcdir, x) for x in cdriz_sources]
 
-    sources = [os.path.join(SRCDIR, x) for x in cdriz_sources]
-
+    cfg = {
+        'include_dirs': [],
+        'libraries': [],
+        'define_macros': []
+    }
     cfg['include_dirs'].append(numpy.get_include())
-    cfg['include_dirs'].append(SRCDIR)
-
+    cfg['include_dirs'].append(srcdir)
     if sys.platform != 'win32':
         cfg['libraries'].append('m')
-
     if sys.platform == 'win32':
         cfg['define_macros'].append(('WIN32', None))
         cfg['define_macros'].append(('__STDC__', 1))


### PR DESCRIPTION
Instead of using the latest version of `numpy` as the build dependency, use the oldest compatible one via the meta package

https://github.com/scipy/oldest-supported-numpy

so that the compiled code can be used with any new version of `numpy` in the runtime environment.

This should resolve the issue discussed in https://github.com/spacetelescope/jwst/issues/5744

For more detail, see https://github.com/pypa/pip/issues/9542