### PR TITLE
Fix memory corruption in the linear blot algorithm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,15 @@
+.. _release_notes:
+
+=============
+Release Notes
+=============
+
+.. 1.14.1 (unreleased)
+   ==================
+
+
+1.14.0 (unreleased)
+===================
+
+- Fix a memory corruption issue in ``interpolate_bilinear()`` in
+  ``cdrizzleblot.c`` which could result in segfault. [#66]

--- a/src/cdrizzleblot.c
+++ b/src/cdrizzleblot.c
@@ -300,8 +300,7 @@ interpolate_bilinear(const void* state UNUSED_PARAM,
                      struct driz_error_t* error UNUSED_PARAM) {
   integer_t nx, ny;
   float sx, tx, sy, ty, f00;
-  float hold21, hold12, hold22;
-  integer_t   isize[2];
+  integer_t isize[2];
 
   get_dimensions(data, isize);
 


### PR DESCRIPTION
Fixes an issue with bilinear interpolator used in the blot function due to which code was trying to access elements outside of the data array resulting in segfault.

This effectively fixes https://github.com/spacetelescope/jwst/issues/6116


This PR also adds a changelog file to this repository though it starts with current issue.