### PR TITLE
Cleanup

### DIFF
--- a/drizzle/__init__.py
+++ b/drizzle/__init__.py
@@ -1,10 +1,7 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """
 A package for combining dithered images into a single image
 """
 
-from __future__ import absolute_import, division, unicode_literals, print_function
 
 from pkg_resources import get_distribution, DistributionNotFound
 try:

--- a/drizzle/calc_pixmap.py
+++ b/drizzle/calc_pixmap.py
@@ -1,6 +1,5 @@
-from __future__ import division, print_function, unicode_literals, absolute_import
-
 import numpy as np
+
 
 def calc_pixmap(first_wcs, second_wcs):
     """

--- a/drizzle/doblot.py
+++ b/drizzle/doblot.py
@@ -1,17 +1,14 @@
-from __future__ import division, print_function, unicode_literals, absolute_import
-
+"""
+STScI Python compatable blot module
+"""
 import numpy as np
 
 from . import calc_pixmap
 from . import cdrizzle
 
 
-"""
-STScI Python compatable blot module
-"""
-
-def doblot(source, source_wcs, blot_wcs, exptime, coeffs = True,
-            interp='poly5', sinscl=1.0, stepsize=10, wcsmap=None):
+def doblot(source, source_wcs, blot_wcs, exptime, coeffs=True,
+           interp='poly5', sinscl=1.0, stepsize=10, wcsmap=None):
     """
     Low level routine for performing the 'blot' operation.
 
@@ -75,7 +72,7 @@ def doblot(source, source_wcs, blot_wcs, exptime, coeffs = True,
     blot_wcs.det2im = None
 
     pixmap = calc_pixmap.calc_pixmap(blot_wcs, source_wcs)
-    pix_ratio = source_wcs.pscale/blot_wcs.pscale
+    pix_ratio = source_wcs.pscale / blot_wcs.pscale
 
     cdrizzle.tblot(source, pixmap, _outsci, scale=pix_ratio, kscale=1.0,
                    interp=interp, exptime=exptime, misval=0.0, sinscl=sinscl)

--- a/drizzle/dodrizzle.py
+++ b/drizzle/dodrizzle.py
@@ -1,16 +1,12 @@
-from __future__ import division, print_function, unicode_literals, absolute_import
-
-# THIRD-PARTY
+"""
+STScI Python compatable drizzle module
+"""
 import numpy as np
 
-# LOCAL
 from . import util
 from . import calc_pixmap
 from . import cdrizzle
 
-"""
-STScI Python compatable drizzle module
-"""
 
 def dodrizzle(insci, input_wcs, inwht,
               output_wcs, outsci, outwht, outcon,
@@ -154,7 +150,7 @@ def dodrizzle(insci, input_wcs, inwht,
 
     # Compute what plane of the context image this input would
     # correspond to:
-    planeid = int((uniqid-1) / 32)
+    planeid = int((uniqid - 1) / 32)
 
     # Check if the context image has this many planes
     if outcon.ndim == 3:

--- a/drizzle/drizzle.py
+++ b/drizzle/drizzle.py
@@ -1,28 +1,18 @@
-# -*- coding: utf-8 -*-
-
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """
 The `drizzle` module defines the `Drizzle` class, for combining input
 images into a single output image using the drizzle algorithm.
 """
-
-from __future__ import division, print_function, unicode_literals, absolute_import
-
-# SYSTEM
 import os
 import os.path
-
-# THIRD-PARTY
 
 import numpy as np
 from astropy import wcs
 from astropy.io import fits
 
-# LOCAL
 from . import util
 from . import doblot
 from . import dodrizzle
+
 
 class Drizzle(object):
     """
@@ -180,11 +170,8 @@ class Drizzle(object):
             self.outwht = np.zeros(self.outwcs.pixel_shape[::-1],
                                    dtype=np.float32)
         if self.outcon is None:
-            self.outcon = np.zeros((1,
-                                    outwcs_naxis2,
-                                    outwcs_naxis1),
-                                    dtype=np.int32)
-
+            self.outcon = np.zeros((1, outwcs_naxis2, outwcs_naxis1),
+                                   dtype=np.int32)
 
     def add_fits_file(self, infile, inweight="",
                       xmin=0, xmax=0, ymin=0, ymax=0,
@@ -286,7 +273,6 @@ class Drizzle(object):
                        xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax,
                        expin=expin, in_units=in_units, wt_scl=wt_scl)
 
-
     def add_image(self, insci, inwcs, inwht=None,
                   xmin=0, xmax=0, ymin=0, ymax=0,
                   expin=1.0, in_units="cps", wt_scl=1.0):
@@ -380,7 +366,6 @@ class Drizzle(object):
                             pixfrac=self.pixfrac, kernel=self.kernel,
                             fillval=self.fillval)
 
-
     def blot_fits_file(self, infile, interp='poly5', sinscl=1.0):
         """
         Resample the output using another image's world coordinate system.
@@ -449,7 +434,6 @@ class Drizzle(object):
 
         self.outwcs = blotwcs
 
-
     def increment_id(self):
         """
         Increment the id count and add a plane to the context image if needed
@@ -473,7 +457,6 @@ class Drizzle(object):
 
         # Increment the id
         self.uniqid += 1
-
 
     def write(self, outfile, out_units="cps", outheader=None):
         """
@@ -546,8 +529,7 @@ class Drizzle(object):
         if out_units == 'counts':
             np.multiply(self.outsci, self.outexptime, self.outsci)
             outexptime = self.outexptime
-        phdu.header['DRIZEXPT'] = \
-        (outexptime, 'Drizzle, exposure time scaling factor')
+        phdu.header['DRIZEXPT'] = (outexptime, 'Drizzle, exposure time scaling factor')
 
         # Copy the optional header to the primary header
 

--- a/drizzle/tests/__init__.py
+++ b/drizzle/tests/__init__.py
@@ -1,4 +1,0 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-This packages contains affiliated package tests.
-"""

--- a/drizzle/tests/test_cdrizzle.py
+++ b/drizzle/tests/test_cdrizzle.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from drizzle import cdrizzle
 
+
 def test_cdrizzle():
     """
     Call C unit tests for cdrizzle, which are in the src/tests directory

--- a/drizzle/tests/test_drizzle.py
+++ b/drizzle/tests/test_drizzle.py
@@ -1,4 +1,3 @@
-import sys
 import math
 import os
 import shutil
@@ -14,16 +13,10 @@ from drizzle import drizzle
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
-OUTPUT_DIR = os.environ.get('DRIZZLE_TEST_OUTPUT_DIR', tempfile.mkdtemp())
 
-
-@pytest.fixture(autouse=True, scope='module')
-def output_dir():
-    yield
-    if 'DRIZZLE_TEST_OUTPUT_DIR' not in os.environ:
-        shutil.rmtree(OUTPUT_DIR)
 
 ok = False
+
 
 def bound_image(image):
     """
@@ -35,6 +28,7 @@ def bound_image(image):
     xmin = coords[1].min()
     xmax = coords[1].max()
     return (ymin, ymax, xmin, xmax)
+
 
 def centroid(image, size, center):
     """
@@ -52,25 +46,29 @@ def centroid(image, size, center):
             center[1] += x * image[y,x]
             center[2] += image[y,x]
 
-    if center[2] == 0.0: return None
+    if center[2] == 0.0:
+        return None
 
     center[0] /= center[2]
     center[1] /= center[2]
     return center
 
+
 def centroid_close(list_of_centroids, size, point):
     """
     Find if any centroid is close to a point
     """
-    for i in range(len(list_of_centroids)-1, -1, -1):
+    for i in range(len(list_of_centroids) - 1, -1, -1):
         if (abs(list_of_centroids[i][0] - point[0]) < int(size / 2) and
-            abs(list_of_centroids[i][1] - point[1]) < int(size / 2)):
+                abs(list_of_centroids[i][1] - point[1]) < int(size / 2)):
             return 1
 
     return 0
 
+
 def centroid_compare(centroid):
     return centroid[1]
+
 
 def centroid_distances(image1, image2, amp, size):
     """
@@ -80,7 +78,8 @@ def centroid_distances(image1, image2, amp, size):
     list_of_centroids = centroid_list(image2, amp, size)
     for center2 in list_of_centroids:
         center1 = centroid(image1, size, center2)
-        if center1 is None: continue
+        if center1 is None:
+            continue
 
         disty = center2[0] - center1[0]
         distx = center2[1] - center1[1]
@@ -90,6 +89,7 @@ def centroid_distances(image1, image2, amp, size):
 
     distances.sort(key=centroid_compare)
     return distances
+
 
 def centroid_list(image, amp, size):
     """
@@ -104,6 +104,7 @@ def centroid_list(image, amp, size):
 
     return list_of_centroids
 
+
 def centroid_statistics(title, fname, image1, image2, amp, size):
     """
     write centroid statistics to compare differences btw two images
@@ -114,7 +115,7 @@ def centroid_statistics(title, fname, image1, image2, amp, size):
 
     diff = []
     distances = centroid_distances(image1, image2, amp, size)
-    indexes = (0, int(len(distances)/2), len(distances)-1)
+    indexes = (0, int(len(distances) / 2), len(distances) - 1)
     fd = open(fname, 'w')
     fd.write("*** %s ***\n" % title)
 
@@ -159,6 +160,7 @@ def centroid_statistics(title, fname, image1, image2, amp, size):
     fd.close()
     return tuple(diff)
 
+
 def make_point_image(input_image, point, value):
     """
     Create an image with a single point set
@@ -167,6 +169,7 @@ def make_point_image(input_image, point, value):
     output_image[point] = value
     return output_image
 
+
 def make_grid_image(input_image, spacing, value):
     """
     Create an image with points on a grid set
@@ -174,12 +177,13 @@ def make_grid_image(input_image, spacing, value):
     output_image = np.zeros(input_image.shape, dtype=input_image.dtype)
 
     shape = output_image.shape
-    half_space = int(spacing/2)
+    half_space = int(spacing / 2)
     for y in range(half_space, shape[0], spacing):
         for x in range(half_space, shape[1], spacing):
             output_image[y,x] = value
 
     return output_image
+
 
 def print_wcs(title, wcs):
     """
@@ -187,6 +191,7 @@ def print_wcs(title, wcs):
     """
     print("=== %s ===" % title)
     print(wcs.to_header_string())
+
 
 def read_image(filename):
     """
@@ -199,6 +204,7 @@ def read_image(filename):
     hdu.close()
     return image
 
+
 def read_wcs(filename):
     """
     Read the wcs of a fits file
@@ -209,13 +215,15 @@ def read_wcs(filename):
     hdu.close()
     return the_wcs
 
-def test_square_with_point():
+
+def test_square_with_point(tmpdir):
     """
     Test do_driz square kernel with point
     """
+    output = str(tmpdir.join('output_square_point.fits'))
+    output_difference = str(tmpdir.join('difference_square_point.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_square_point.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_square_point.txt')
     output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
 
     insci = read_image(input_file)
@@ -233,19 +241,23 @@ def test_square_with_point():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("square with point", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics("square with point",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 8)
 
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 1.0e-5)
+        assert med_diff < 1.0e-6
+        assert max_diff < 1.0e-5
 
-def test_square_with_grid():
+
+def test_square_with_grid(tmpdir):
     """
     Test do_driz square kernel with grid
     """
+    output = str(tmpdir.join('output_square_grid.fits'))
+    output_difference = str(tmpdir.join('difference_square_grid.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_square_grid.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_square_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_square_grid.fits')
 
     insci = read_image(input_file)
@@ -263,19 +275,22 @@ def test_square_with_grid():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("square with grid", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics("square with grid",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 8)
+        assert med_diff < 1.0e-6
+        assert max_diff < 1.0e-5
 
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 1.0e-5)
 
-def test_turbo_with_grid():
+def test_turbo_with_grid(tmpdir):
     """
     Test do_driz turbo kernel with grid
     """
+    output = str(tmpdir.join('output_turbo_grid.fits'))
+    output_difference = str(tmpdir.join('difference_turbo_grid.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_turbo_grid.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_turbo_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_turbo_grid.fits')
 
     insci = read_image(input_file)
@@ -293,19 +308,23 @@ def test_turbo_with_grid():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("turbo with grid", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics("turbo with grid",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 8)
 
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 1.0e-5)
+        assert med_diff < 1.0e-6
+        assert max_diff < 1.0e-5
 
-def test_gaussian_with_grid():
+
+def test_gaussian_with_grid(tmpdir):
     """
     Test do_driz gaussian kernel with grid
     """
+    output = str(tmpdir.join('output_gaussian_grid.fits'))
+    output_difference = str(tmpdir.join('difference_gaussian_grid.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_gaussian_grid.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_gaussian_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_gaussian_grid.fits')
 
     insci = read_image(input_file)
@@ -323,19 +342,23 @@ def test_gaussian_with_grid():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("gaussian with grid", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics("gaussian with grid",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 8)
 
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 2.0e-5)
+        assert med_diff < 1.0e-6
+        assert max_diff < 2.0e-5
 
-def test_lanczos_with_grid():
+
+def test_lanczos_with_grid(tmpdir):
     """
     Test do_driz lanczos kernel with grid
     """
+    output = str(tmpdir.join('output_lanczos_grid.fits'))
+    output_difference = str(tmpdir.join('difference_lanczos_grid.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_lanczos_grid.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_lanczos_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_lanczos_grid.fits')
 
     insci = read_image(input_file)
@@ -353,19 +376,22 @@ def test_lanczos_with_grid():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("lanczos with grid", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics("lanczos with grid",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 8)
+        assert med_diff < 1.0e-6
+        assert max_diff < 1.0e-5
 
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 1.0e-5)
 
-def test_tophat_with_grid():
+def test_tophat_with_grid(tmpdir):
     """
     Test do_driz tophat kernel with grid
     """
+    output = str(tmpdir.join('output_tophat_grid.fits'))
+    output_difference = str(tmpdir.join('difference_tophat_grid.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_tophat_grid.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_tophat_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_tophat_grid.fits')
 
     insci = read_image(input_file)
@@ -383,19 +409,22 @@ def test_tophat_with_grid():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("tophat with grid", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics("tophat with grid",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 8)
+        assert med_diff < 1.0e-6
+        assert max_diff < 1.0e-5
 
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 1.0e-5)
 
-def test_point_with_grid():
+def test_point_with_grid(tmpdir):
     """
     Test do_driz point kernel with grid
     """
+    output = str(tmpdir.join('output_point_grid.fits'))
+    output_difference = str(tmpdir.join('difference_point_grid.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_point_grid.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_point_grid.txt')
     output_template = os.path.join(DATA_DIR, 'reference_point_grid.fits')
 
     insci = read_image(input_file)
@@ -413,19 +442,22 @@ def test_point_with_grid():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("point with grid", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics("point with grid",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 8)
+        assert med_diff < 1.0e-6
+        assert max_diff < 1.0e-5
 
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 1.0e-5)
 
-def test_blot_with_point():
+def test_blot_with_point(tmpdir):
     """
     Test do_blot with point image
     """
+    output = str(tmpdir.join('output_blot_point.fits'))
+    output_difference = str(tmpdir.join('difference_blot_point.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_blot_point.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_blot_point.txt')
     output_template = os.path.join(DATA_DIR, 'reference_blot_point.fits')
 
     outsci = read_image(input_file)
@@ -444,18 +476,22 @@ def test_blot_with_point():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("blot with point", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 16)
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 1.0e-5)
+        min_diff, med_diff, max_diff = centroid_statistics("blot with point",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 16)
+        assert med_diff < 1.0e-6
+        assert max_diff < 1.0e-5
 
-def test_blot_with_default():
+
+def test_blot_with_default(tmpdir):
     """
     Test do_blot with default grid image
     """
+    output = str(tmpdir.join('output_blot_default.fits'))
+    output_difference = str(tmpdir.join('difference_blot_default.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_blot_default.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_blot_default.txt')
     output_template = os.path.join(DATA_DIR, 'reference_blot_default.fits')
 
     outsci = read_image(input_file)
@@ -474,19 +510,23 @@ def test_blot_with_default():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("blot with defaults", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 16)
+        min_diff, med_diff, max_diff = centroid_statistics("blot with defaults",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 16)
 
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 1.0e-5)
+        assert med_diff < 1.0e-6
+        assert max_diff < 1.0e-5
 
-def test_blot_with_lan3():
+
+def test_blot_with_lan3(tmpdir):
     """
     Test do_blot with lan3 grid image
     """
+    output = str(tmpdir.join('output_blot_lan3.fits'))
+    output_difference = str(tmpdir.join('difference_blot_lan3.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_blot_lan3.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_blot_lan3.txt')
     output_template = os.path.join(DATA_DIR, 'reference_blot_lan3.fits')
 
     outsci = read_image(input_file)
@@ -505,19 +545,22 @@ def test_blot_with_lan3():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("blot with lan3", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 16)
+        min_diff, med_diff, max_diff = centroid_statistics("blot with lan3",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 16)
+        assert med_diff < 1.0e-6
+        assert max_diff < 1.0e-5
 
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 1.0e-5)
 
-def test_blot_with_lan5():
+def test_blot_with_lan5(tmpdir):
     """
     Test do_blot with lan5 grid image
     """
+    output = str(tmpdir.join('output_blot_lan5.fits'))
+    output_difference = str(tmpdir.join('difference_blot_lan5.txt'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output = os.path.join(OUTPUT_DIR, 'output_blot_lan5.fits')
-    output_difference = os.path.join(OUTPUT_DIR, 'difference_blot_lan5.txt')
     output_template = os.path.join(DATA_DIR, 'reference_blot_lan5.fits')
 
     outsci = read_image(input_file)
@@ -536,8 +579,9 @@ def test_blot_with_lan5():
         driz.write(output)
         template_data = read_image(output_template)
 
-        (min_diff, med_diff, max_diff) = centroid_statistics("blot with lan5", output_difference,
-                                                                  driz.outsci, template_data, 20.0, 16)
-
-        assert(med_diff < 1.0e-6)
-        assert(max_diff < 1.0e-5)
+        min_diff, med_diff, max_diff = centroid_statistics("blot with lan5",
+                                                           output_difference,
+                                                           driz.outsci,
+                                                           template_data, 20.0, 16)
+        assert med_diff < 1.0e-6
+        assert max_diff < 1.0e-5

--- a/drizzle/tests/test_drizzle.py
+++ b/drizzle/tests/test_drizzle.py
@@ -17,7 +17,7 @@ DATA_DIR = os.path.join(TEST_DIR, 'data')
 OUTPUT_DIR = os.environ.get('DRIZZLE_TEST_OUTPUT_DIR', tempfile.mkdtemp())
 
 
-@pytest.yield_fixture(autouse=True, scope='module')
+@pytest.fixture(autouse=True, scope='module')
 def output_dir():
     yield
     if 'DRIZZLE_TEST_OUTPUT_DIR' not in os.environ:
@@ -541,23 +541,3 @@ def test_blot_with_lan5():
 
         assert(med_diff < 1.0e-6)
         assert(max_diff < 1.0e-5)
-
-if __name__ == "__main__":
-    """
-    Run tests from command line
-    """
-    for flag in sys.argv[1:]:
-        if flag == 'ok':
-            ok = True
-
-    test_square_with_point()
-    test_square_with_grid()
-    test_turbo_with_grid()
-    test_gaussian_with_grid()
-    test_lanczos_with_grid()
-    test_tophat_with_grid()
-    test_point_with_grid()
-    test_blot_with_point()
-    test_blot_with_default()
-    test_blot_with_lan3()
-    test_blot_with_lan5()

--- a/drizzle/tests/test_drizzle.py
+++ b/drizzle/tests/test_drizzle.py
@@ -1,9 +1,6 @@
 import math
 import os
-import shutil
-import tempfile
 
-import pytest
 import numpy as np
 from astropy import wcs
 from astropy.io import fits
@@ -127,7 +124,8 @@ def centroid_statistics(title, fname, image1, image2, amp, size):
         diff = [distances[0][0], distances[0][0], distances[0][0]]
 
         fd.write("1 match\n")
-        fd.write("distance = %f flux difference = %f\n" % (distances[0][0], distances[0][1]))
+        fd.write("distance = %f flux difference = %f\n" %
+                 (distances[0][0], distances[0][1]))
 
         for j in range(2, 4):
             ylo = int(distances[0][j][0]) - 1
@@ -136,7 +134,8 @@ def centroid_statistics(title, fname, image1, image2, amp, size):
             xhi = int(distances[0][j][1]) + 2
             subimage = images[j][ylo:yhi,xlo:xhi]
             fd.write("\n%s image centroid = (%f,%f) image flux = %f\n" %
-                     (im_type[j], distances[0][j][0], distances[0][j][1], distances[0][j][2]))
+                     (im_type[j], distances[0][j][0], distances[0][j][1],
+                      distances[0][j][2]))
             fd.write(str(subimage) + "\n")
 
     else:
@@ -145,7 +144,8 @@ def centroid_statistics(title, fname, image1, image2, amp, size):
         for k in range(0,3):
             i = indexes[k]
             diff.append(distances[i][0])
-            fd.write("\n%s distance = %f flux difference = %f\n" % (stats[k], distances[i][0], distances[i][1]))
+            fd.write("\n%s distance = %f flux difference = %f\n" %
+                     (stats[k],distances[i][0], distances[i][1]))
 
             for j in range(2, 4):
                 ylo = int(distances[i][j][0]) - 1
@@ -154,7 +154,8 @@ def centroid_statistics(title, fname, image1, image2, amp, size):
                 xhi = int(distances[i][j][1]) + 2
                 subimage = images[j][ylo:yhi,xlo:xhi]
                 fd.write("\n%s %s image centroid = (%f,%f) image flux = %f\n" %
-                         (stats[k], im_type[j], distances[i][j][0], distances[i][j][1], distances[i][j][2]))
+                         (stats[k], im_type[j], distances[i][j][0],
+                          distances[i][j][1], distances[i][j][2]))
                 fd.write(str(subimage) + "\n")
 
     fd.close()

--- a/drizzle/tests/test_file_io.py
+++ b/drizzle/tests/test_file_io.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-import tempfile
 
 import pytest
 import numpy as np

--- a/drizzle/tests/test_file_io.py
+++ b/drizzle/tests/test_file_io.py
@@ -16,7 +16,7 @@ DATA_DIR = os.path.join(TEST_DIR, 'data')
 OUTPUT_DIR = os.environ.get('DRIZZLE_TEST_OUTPUT_DIR', tempfile.mkdtemp())
 
 
-@pytest.yield_fixture(autouse=True, scope='module')
+@pytest.fixture(autouse=True, scope='module')
 def output_dir():
     yield
     if 'DRIZZLE_TEST_OUTPUT_DIR' not in os.environ:

--- a/drizzle/tests/test_file_io.py
+++ b/drizzle/tests/test_file_io.py
@@ -13,14 +13,6 @@ from drizzle import util
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 DATA_DIR = os.path.join(TEST_DIR, 'data')
-OUTPUT_DIR = os.environ.get('DRIZZLE_TEST_OUTPUT_DIR', tempfile.mkdtemp())
-
-
-@pytest.fixture(autouse=True, scope='module')
-def output_dir():
-    yield
-    if 'DRIZZLE_TEST_OUTPUT_DIR' not in os.environ:
-        shutil.rmtree(OUTPUT_DIR)
 
 
 def read_header(filename):
@@ -28,10 +20,8 @@ def read_header(filename):
     Read the primary header from a fits file
     """
     fileroot, extn = util.parse_filename(os.path.join(DATA_DIR, filename))
-    hdu = fits.open(fileroot)
-
-    header = hdu[0].header
-    hdu.close()
+    with fits.open(fileroot) as hdulist:
+        header = hdulist[0].header
     return header
 
 
@@ -40,11 +30,9 @@ def read_image(filename):
     Read the image from a fits file
     """
     fileroot, extn = util.parse_filename(os.path.join(DATA_DIR, filename))
-    hdu = fits.open(fileroot)
-
-    image = hdu[1].data
-    hdu.close()
-    return image
+    with fits.open(fileroot, memmap=False) as hdulist:
+        data = hdulist[1].data.copy()
+    return data
 
 
 def read_wcs(filename):
@@ -52,69 +40,68 @@ def read_wcs(filename):
     Read the wcs of a fits file
     """
     fileroot, extn = util.parse_filename(os.path.join(DATA_DIR, filename))
-    hdu = fits.open(fileroot)
-
-    the_wcs = wcs.WCS(hdu[1].header)
-    hdu.close()
+    with fits.open(fileroot) as hdulist:
+        the_wcs = wcs.WCS(hdulist[1].header)
     return the_wcs
 
 
-def test_null_run():
-    """
-    Create an empty drizzle image
-    """
-    output_file = os.path.join(OUTPUT_DIR, 'output_null_run.fits')
+@pytest.fixture
+def run_drizzle_reference_square_points(tmpdir):
+    """Create an empty drizzle image"""
+    output_file = str(tmpdir.join('output_null_run.fits'))
     output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
 
     output_wcs = read_wcs(output_template)
-    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="expsq",
-                                   pixfrac=0.5, kernel="turbo",
-                                   fillval="NaN")
+    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="expsq", pixfrac=0.5,
+                           kernel="turbo", fillval="NaN")
     driz.write(output_file)
 
-    assert(os.path.exists(output_file))
-    handle = fits.open(output_file)
-
-    assert(handle.index_of("SCI") == 1)
-    assert(handle.index_of("WHT") == 2)
-    assert(handle.index_of("CTX") == 3)
-
-    pheader = handle[0].header
-    assert(pheader['DRIZOUDA'] == 'SCI')
-    assert(pheader['DRIZOUWE'] == 'WHT')
-    assert(pheader['DRIZOUCO'] == 'CTX')
-    assert(pheader['DRIZWTSC'] == 'expsq')
-    assert(pheader['DRIZKERN'] == 'turbo')
-    assert(pheader['DRIZPIXF'] == 0.5)
-    assert(pheader['DRIZFVAL'] == 'NaN')
-    assert(pheader['DRIZOUUN'] == 'cps')
-    assert(pheader['EXPTIME'] == 0.0)
-    assert(pheader['DRIZEXPT'] == 1.0)
+    return output_file
 
 
-def test_file_init():
+def test_null_run(run_drizzle_reference_square_points):
+    output_file = run_drizzle_reference_square_points
+    with fits.open(output_file) as hdulist:
+
+        assert hdulist.index_of("SCI") == 1
+        assert hdulist.index_of("WHT") == 2
+        assert hdulist.index_of("CTX") == 3
+
+        pheader = hdulist["PRIMARY"].header
+
+    assert pheader['DRIZOUDA'] == 'SCI'
+    assert pheader['DRIZOUWE'] == 'WHT'
+    assert pheader['DRIZOUCO'] == 'CTX'
+    assert pheader['DRIZWTSC'] == 'expsq'
+    assert pheader['DRIZKERN'] == 'turbo'
+    assert pheader['DRIZPIXF'] == 0.5
+    assert pheader['DRIZFVAL'] == 'NaN'
+    assert pheader['DRIZOUUN'] == 'cps'
+    assert pheader['EXPTIME'] == 0.0
+    assert pheader['DRIZEXPT'] == 1.0
+
+
+def test_file_init(run_drizzle_reference_square_points):
     """
     Initialize drizzle object from a file
     """
-    input_file = os.path.join(OUTPUT_DIR, 'output_null_run.fits')
-    output_file = os.path.join(OUTPUT_DIR, 'output_null_run.fits')
+    input_file = run_drizzle_reference_square_points
 
     driz = drizzle.Drizzle(infile=input_file)
-    driz.write(output_file)
 
-    assert(driz.outexptime == 1.0)
-    assert(driz.wt_scl == 'expsq')
-    assert(driz.kernel == 'turbo')
-    assert(driz.pixfrac == 0.5)
-    assert(driz.fillval == 'NaN')
+    assert driz.outexptime == 1.0
+    assert driz.wt_scl == 'expsq'
+    assert driz.kernel == 'turbo'
+    assert driz.pixfrac == 0.5
+    assert driz.fillval == 'NaN'
 
 
-def test_add_header():
-    """
-    Add extra keywords read from the header
-    """
+@pytest.fixture
+def add_header(tmpdir):
+    """Add extra keywords read from the header"""
+    output_file = str(tmpdir.join('output_add_header.fits'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_file = os.path.join(OUTPUT_DIR, 'output_add_header.fits')
     output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
 
     driz = drizzle.Drizzle(infile=output_template)
@@ -128,19 +115,25 @@ def test_add_header():
 
     driz.write(output_file, outheader=header)
 
+    return output_file
+
+
+def test_add_header(add_header):
+    output_file = add_header
     header = read_header(output_file)
-    assert(header['ONEVAL'] == 1.0)
-    assert(header['TWOVAL'] == 2.0)
-    assert(header['DRIZKERN'] == 'square')
+    assert header['ONEVAL'] == 1.0
+    assert header['TWOVAL'] == 2.0
+    assert header['DRIZKERN'] == 'square'
 
 
-def test_add_file():
+def test_add_file(add_header, tmpdir):
     """
     Add an image read from a file
     """
+    test_file = add_header
+    output_file = str(tmpdir.join('output_add_file.fits'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits[1]')
-    output_file = os.path.join(OUTPUT_DIR, 'output_add_file.fits')
-    test_file = os.path.join(OUTPUT_DIR, 'output_add_header.fits')
     output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
 
     driz = drizzle.Drizzle(infile=output_template)
@@ -148,18 +141,20 @@ def test_add_file():
     driz.write(output_file)
 
     output_image = read_image(output_file)
-    test_image =  read_image(test_file)
+    test_image = read_image(test_file)
     diff_image = np.absolute(output_image - test_image)
-    assert(np.amax(diff_image) == 0.0)
+
+    assert np.amax(diff_image) == 0.0
 
 
-def test_blot_file():
+def test_blot_file(tmpdir):
     """
     Blot an image read from a file
     """
+    output_file = str(tmpdir.join('output_blot_file.fits'))
+    test_file = str(tmpdir.join('output_blot_image.fits'))
+
     input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits[1]')
-    output_file = os.path.join(OUTPUT_DIR, 'output_blot_file.fits')
-    test_file = os.path.join(OUTPUT_DIR, 'output_blot_image.fits')
     output_template = os.path.join(DATA_DIR, 'reference_blot_image.fits')
 
     blotwcs = read_wcs(input_file)
@@ -175,6 +170,7 @@ def test_blot_file():
     driz.write(output_file)
 
     output_image = read_image(output_file)
-    test_image =  read_image(test_file)
+    test_image = read_image(test_file)
     diff_image = np.absolute(output_image - test_image)
-    assert(np.amax(diff_image) == 0.0)
+
+    assert np.amax(diff_image) == 0.0

--- a/drizzle/tests/test_pixmap.py
+++ b/drizzle/tests/test_pixmap.py
@@ -1,7 +1,7 @@
 import os.path
 
 import numpy as np
-import numpy.testing as npt
+from numpy.testing import assert_equal, assert_almost_equal
 from astropy import wcs
 from astropy.io import fits
 
@@ -21,7 +21,8 @@ def test_map_rectangular():
 
     pixmap = np.indices((naxis1, naxis2), dtype='float32')
     pixmap = pixmap.transpose()
-    npt.assert_equal(pixmap[5,500], (500,5))
+
+    assert_equal(pixmap[5,500], (500,5))
 
 
 def test_map_to_self():
@@ -39,8 +40,11 @@ def test_map_to_self():
     ok_pixmap = ok_pixmap.transpose()
 
     pixmap = calc_pixmap.calc_pixmap(input_wcs, input_wcs)
-    npt.assert_equal(pixmap.shape, ok_pixmap.shape) # Got x-y transpose right
-    npt.assert_almost_equal(pixmap, ok_pixmap, decimal=5) # Mapping an array to itself
+
+    # Got x-y transpose right
+    assert_equal(pixmap.shape, ok_pixmap.shape)
+    # Mapping an array to itself
+    assert_almost_equal(pixmap, ok_pixmap, decimal=5)
 
 
 def test_translated_map():
@@ -66,5 +70,8 @@ def test_translated_map():
     ok_pixmap = ok_pixmap.transpose()
 
     pixmap = calc_pixmap.calc_pixmap(first_wcs, second_wcs)
-    npt.assert_equal(pixmap.shape, ok_pixmap.shape) # Got x-y transpose right
-    npt.assert_almost_equal(pixmap, ok_pixmap, decimal=5) # Mapping an array to a translated array
+
+    # Got x-y transpose right
+    assert_equal(pixmap.shape, ok_pixmap.shape)
+    # Mapping an array to a translated array
+    assert_almost_equal(pixmap, ok_pixmap, decimal=5)

--- a/drizzle/util.py
+++ b/drizzle/util.py
@@ -248,5 +248,5 @@ def set_pscale(the_wcs):
             pc = 1
 
     pccd = np.array(cdelt * pc)
-    scales = np.sqrt((pccd ** 2).sum(axis=0, dtype=np.float))
+    scales = np.sqrt((pccd ** 2).sum(axis=0, dtype=float))
     the_wcs.pscale = scales[0]

--- a/drizzle/util.py
+++ b/drizzle/util.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function, unicode_literals, absolute_import
-
 import numpy as np
 
 
@@ -46,6 +44,7 @@ def find_keyword_extn(fimg, keyword, value=None):
     # Return the index of the extension which contained the
     # desired EXTNAME value.
     return extnum
+
 
 def get_extn(fimg, extn=''):
     """
@@ -98,6 +97,7 @@ def get_extn(fimg, extn=''):
 
     return _extn
 
+
 def get_keyword(fimg, keyword, default=None):
     """
     Return a keyword value from the header of an image,
@@ -134,6 +134,7 @@ def get_keyword(fimg, keyword, default=None):
 
     return value
 
+
 def is_blank(value):
     """
     Determines whether or not a value is considered 'blank'.
@@ -150,6 +151,7 @@ def is_blank(value):
     True or False
     """
     return value.strip() == ""
+
 
 def parse_extn(extn=''):
     """
@@ -191,6 +193,7 @@ def parse_extn(extn=''):
     else:
         return (lext[0], 1)
 
+
 def parse_filename(filename):
     """
     Parse out filename from any specified extensions.
@@ -212,12 +215,13 @@ def parse_filename(filename):
     if _indx > 0:
         # Read extension name provided
         _fname = filename[:_indx]
-        _extn = filename[_indx+1:-1]
+        _extn = filename[_indx + 1:-1]
     else:
         _fname = filename
         _extn = ''
 
     return _fname, _extn
+
 
 def set_pscale(the_wcs):
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ packages = find:
 test =
     pytest
     pytest-cov
-    pytest-doctestplus
     coverage
     flake8
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,17 +43,16 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [flake8]
-max-line-length = 160
-select =
-    F,
-    E101,
-    E111,
-    E112,
-    E113,
-    E401,
-    E402,
-    E711,
-    E722
+max-line-length = 100
+select = F, W, E, C
+ignore =
+    E231, # Missing whitespace after ',', ';', or ':'
+    W503, # Line break occurred before a binary operator
+    W504, # Line break occurred after a binary operator
+exclude =
+    docs,
+    .eggs
+
 
 [tool:pytest]
 minversion = 4.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,10 +23,11 @@ packages = find:
 
 [options.extras_require]
 test =
-    pytest>=4.6.0
+    pytest
     pytest-cov
+    pytest-doctestplus
     coverage
-    flake8>=3.6.0
+    flake8
 docs =
     matplotlib
     sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,6 @@ envlist =
     build_docs
     codestyle
     bandit
-requires =
-    setuptools >= 30.3.0
-    pip >= 19.3.1
 isolated_build = true
 
 [testenv]
@@ -28,18 +25,15 @@ description =
 
 # The following provides some specific pinnings for key packages
 deps =
-    cov: coverage
-
     devdeps: git+https://github.com/astropy/astropy
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test
 
+usedevelop = true
+
 commands =
-    # FIXME: Not sure why need this for tox to see the C-ext
-    python setup.py build_ext --inplace
-    # End of FIXME
     pip freeze
     !cov: pytest
     cov: pytest --cov-report xml --cov drizzle


### PR DESCRIPTION
- PEP8 cleanup and check all the `flake8` codes in CI by default from now on
- Don't rely on tests being run in a particular order.  Use fixtures for 2 tests that depend on a single result.
- Use `tmpdir` for test output instead of home-grown solution
- Remove python 2 cruft