### PR TITLE
Changes to drizzle to switch from single to double precision.

### DIFF
--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -30,10 +30,10 @@ FILE *driz_log_handle = NULL;
 static void
 scale_image(PyArrayObject *image, double scale_factor) {
   long  i, size;
-  float *imptr;
+  double *imptr;
 
   assert(image);
-  imptr = (float *) PyArray_DATA(image);
+  imptr = (double *) PyArray_DATA(image);
 
   size = PyArray_DIMS(image)[0] * PyArray_DIMS(image)[1];
 
@@ -68,8 +68,8 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
   double pfract = 1.0;
   char *kernel_str = "square";
   char *inun_str = "cps";
-  float expin = 1.0;
-  float wtscl = 1.0;
+  double expin = 1.0;
+  double wtscl = 1.0;
   char *fillstr = "INDEF";
 
   /* Derived values */
@@ -79,8 +79,8 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
   enum e_unit_t inun;
   char *fillstr_end;
   bool_t do_fill;
-  float fill_value;
-  float inv_exposure_time;
+  double fill_value;
+  double inv_exposure_time;
   struct driz_error_t error;
   struct driz_param_t p;
   integer_t isize[2], psize[2], wsize[2];
@@ -278,11 +278,11 @@ tblot(PyObject *obj, PyObject *args, PyObject *keywords)
   long ymin = 0;
   long ymax = 0;
   double scale = 1.0;
-  float kscale = 1.0;
+  double kscale = 1.0;
   char *interp_str = "poly5";
-  float ef = 1.0;
-  float misval = 0.0;
-  float sinscl = 1.0;
+  double ef = 1.0;
+  double misval = 0.0;
+  double sinscl = 1.0;
 
   PyArrayObject *img = NULL, *out = NULL, *map = NULL;
   enum e_interp_t interp;

--- a/src/cdrizzleblot.c
+++ b/src/cdrizzleblot.c
@@ -19,9 +19,9 @@
 
 typedef int (interp_function)(const void*,
                               PyArrayObject*,
-                              const float, const float,
+                              const double, const double,
                               /* Output parameters */
-                              float*,
+                              double*,
                               struct driz_error_t*);
 
 /** --------------------------------------------------------------------------------------------------
@@ -32,8 +32,8 @@ typedef int (interp_function)(const void*,
   assert(data); \
   assert(isize[0] > 0); \
   assert(isize[1] > 0); \
-  assert(x >= 0.0f && x < (float)isize[0]);      \
-  assert(y >= 0.0f && y < (float)isize[1]);      \
+  assert(x >= 0.0f && x < (double)isize[0]);      \
+  assert(y >= 0.0f && y < (double)isize[1]);      \
   assert(value); \
   assert(error); \
 
@@ -43,7 +43,7 @@ typedef int (interp_function)(const void*,
 
 struct sinc_param_t {
   /*The scaling factor for sinc interpolation */
-  float sinscl;
+  double sinscl;
 };
 
 /** --------------------------------------------------------------------------------------------------
@@ -62,15 +62,15 @@ struct sinc_param_t {
  */
 
 static inline_macro void
-ii_bipoly3(const float* coeff /* [len_coeff][len_coeff] */,
+ii_bipoly3(const double* coeff /* [len_coeff][len_coeff] */,
            const integer_t len_coeff, const integer_t firstt,
            const integer_t npts,
-           const float* x /* [npts] */, const float* y /* [npts] */,
+           const double* x /* [npts] */, const double* y /* [npts] */,
            /* Output parameters */
-           float* zfit /* [npts] */) {
-  float sx, tx, sx2m1, tx2m1, sy, ty;
-  float cd20[4], cd21[4], ztemp[4];
-  float cd20y, cd21y;
+           double* zfit /* [npts] */) {
+  double sx, tx, sx2m1, tx2m1, sy, ty;
+  double cd20[4], cd21[4], ztemp[4];
+  double cd20y, cd21y;
   integer_t nxold, nyold;
   integer_t nx, ny;
   integer_t firstw, index;
@@ -81,7 +81,7 @@ ii_bipoly3(const float* coeff /* [len_coeff][len_coeff] */,
     nx = (integer_t)x[i];
     assert(nx >= 0);
 
-    sx = x[i] - (float)nx;
+    sx = x[i] - (double)nx;
     tx = 1.0f - sx;
     sx2m1 = sx*sx - 1.0f;
     tx2m1 = tx*tx - 1.0f;
@@ -89,7 +89,7 @@ ii_bipoly3(const float* coeff /* [len_coeff][len_coeff] */,
     ny = (integer_t)y[i];
     assert(ny >= 0);
 
-    sy = y[i] - (float)ny;
+    sy = y[i] - (double)ny;
     ty = 1.0f - sy;
 
     /* Calculate pointer to data[nx, ny-1] */
@@ -149,19 +149,19 @@ ii_bipoly3(const float* coeff /* [len_coeff][len_coeff] */,
  */
 
 static inline_macro void
-ii_bipoly5(const float* coeff /* [len_coeff][len_coeff] */,
+ii_bipoly5(const double* coeff /* [len_coeff][len_coeff] */,
            const integer_t len_coeff, const integer_t firstt,
            const integer_t npts,
-           const float* x /* [npts] */, const float* y /* [npts] */,
+           const double* x /* [npts] */, const double* y /* [npts] */,
            /* Output parameters */
-           float* zfit /* [npts] */) {
+           double* zfit /* [npts] */) {
   integer_t nxold, nyold;
   integer_t nx, ny;
-  float sx, sx2, tx, tx2, sy, sy2, ty, ty2;
-  float sx2m1, sx2m4, tx2m1, tx2m4;
-  float cd20[6], cd21[6], cd40[6], cd41[6];
-  float cd20y, cd21y, cd40y, cd41y;
-  float ztemp[6];
+  double sx, sx2, tx, tx2, sy, sy2, ty, ty2;
+  double sx2m1, sx2m4, tx2m1, tx2m4;
+  double cd20[6], cd21[6], cd40[6], cd41[6];
+  double cd20y, cd21y, cd40y, cd41y;
+  double ztemp[6];
   integer_t firstw, index;
   integer_t i, j;
 
@@ -179,7 +179,7 @@ ii_bipoly5(const float* coeff /* [len_coeff][len_coeff] */,
     assert(nx >= 0);
     assert(ny >= 0);
 
-    sx = x[i] - (float)nx;
+    sx = x[i] - (double)nx;
     sx2 = sx * sx;
     sx2m1 = sx2 - 1.0f;
     sx2m4 = sx2 - 4.0f;
@@ -188,7 +188,7 @@ ii_bipoly5(const float* coeff /* [len_coeff][len_coeff] */,
     tx2m1 = tx2 - 1.0f;
     tx2m4 = tx2 - 4.0f;
 
-    sy = y[i] - (float)ny;
+    sy = y[i] - (double)ny;
     sy2 = sy * sy;
     ty = 1.0f - sy;
     ty2 = ty * ty;
@@ -265,9 +265,9 @@ ii_bipoly5(const float* coeff /* [len_coeff][len_coeff] */,
 static int
 interpolate_nearest_neighbor(const void* state UNUSED_PARAM,
                              PyArrayObject* data,
-                             const float x, const float y,
+                             const double x, const double y,
                              /* Output parameters */
-                             float* value,
+                             double* value,
                              struct driz_error_t* error UNUSED_PARAM) {
 
   integer_t   isize[2];
@@ -294,12 +294,12 @@ interpolate_nearest_neighbor(const void* state UNUSED_PARAM,
 static int
 interpolate_bilinear(const void* state UNUSED_PARAM,
                      PyArrayObject* data,
-                     const float x, const float y,
+                     const double x, const double y,
                      /* Output parameters */
-                     float* value,
+                     double* value,
                      struct driz_error_t* error UNUSED_PARAM) {
   integer_t nx, ny;
-  float sx, tx, sy, ty, f00;
+  double sx, tx, sy, ty, f00;
   integer_t isize[2];
 
   get_dimensions(data, isize);
@@ -325,17 +325,17 @@ interpolate_bilinear(const void* state UNUSED_PARAM,
       return 0;
     }
     /* Interpolate along Y-direction only */
-    sy = y - (float)ny;
+    sy = y - (double)ny;
     *value = (1.0f - sy) * f00 + sy * get_pixel(data, nx, ny + 1);
   } else if (ny == (isize[1] - 1)) {
     /* Interpolate along X-direction only */
-    sx = x - (float)nx;
+    sx = x - (double)nx;
     *value = (1.0f - sx) * f00 + sx * get_pixel(data, nx + 1, ny);
   } else {
     /* Bilinear - interpolation */
-    sx = x - (float)nx;
+    sx = x - (double)nx;
     tx = 1.0f - sx;
-    sy = y - (float)ny;
+    sy = y - (double)ny;
     ty = 1.0f - sy;
 
     *value = tx * ty * f00 +
@@ -361,18 +361,18 @@ interpolate_bilinear(const void* state UNUSED_PARAM,
 static int
 interpolate_poly3(const void* state UNUSED_PARAM,
                   PyArrayObject* data,
-                  const float x, const float y,
+                  const double x, const double y,
                   /* Output parameters */
-                  float* value,
+                  double* value,
                   struct driz_error_t* error UNUSED_PARAM) {
   integer_t nx, ny;
   const integer_t rowleh = 4;
   const integer_t nterms = 4;
-  float coeff[4][4];
+  double coeff[4][4];
   integer_t i, j;
   integer_t firstw, lastrw;
-  float xval, yval;
-  float* ci;
+  double xval, yval;
+  double* ci;
   integer_t   isize[2];
   get_dimensions(data, isize);
 
@@ -453,8 +453,8 @@ interpolate_poly3(const void* state UNUSED_PARAM,
                          &coeff[3][0]);
   }
 
-  xval = 2.0f + (x - (float)nx);
-  yval = 2.0f + (y - (float)ny);
+  xval = 2.0f + (x - (double)nx);
+  yval = 2.0f + (y - (double)ny);
 
   ii_bipoly3(&coeff[0][0], rowleh, 0, 1, &xval, &yval, value);
 
@@ -475,18 +475,18 @@ interpolate_poly3(const void* state UNUSED_PARAM,
 static int
 interpolate_poly5(const void* state UNUSED_PARAM,
                   PyArrayObject* data,
-                  const float x, const float y,
+                  const double x, const double y,
                   /* Output parameters */
-                  float* value,
+                  double* value,
                   struct driz_error_t* error UNUSED_PARAM) {
   integer_t nx, ny;
   const integer_t rowleh = 6;
   const integer_t nterms = 6;
-  float coeff[6][6];
+  double coeff[6][6];
   integer_t i, j;
   integer_t firstw, lastrw;
-  float xval, yval;
-  float* ci;
+  double xval, yval;
+  double* ci;
   integer_t   isize[2];
   get_dimensions(data, isize);
 
@@ -563,8 +563,8 @@ interpolate_poly5(const void* state UNUSED_PARAM,
                          &coeff[5][0]);
   }
 
-  xval = 3.0f + (x - (float)nx);
-  yval = 3.0f + (y - (float)ny);
+  xval = 3.0f + (x - (double)nx);
+  yval = 3.0f + (y - (double)ny);
 
   ii_bipoly5(&coeff[0][0], rowleh, 0, 1, &xval, &yval, value);
 
@@ -580,25 +580,25 @@ interpolate_poly5(const void* state UNUSED_PARAM,
 static inline_macro int
 interpolate_sinc_(PyArrayObject* data,
                   const integer_t firstt, const integer_t npts,
-                  const float* x /*[npts]*/, const float* y /*[npts]*/,
-                  const float mindx, const float mindy,
-                  const float sinscl,
+                  const double* x /*[npts]*/, const double* y /*[npts]*/,
+                  const double mindx, const double mindy,
+                  const double sinscl,
                   /* Output parameters */
-                  float* value,
+                  double* value,
                   struct driz_error_t* error UNUSED_PARAM) {
   const integer_t nconv = INTERPOLATE_SINC_NCONV;
   const integer_t nsinc = (nconv - 1) / 2;
   /* TODO: This is to match Fortan, but is probably technically less precise */
-  const float halfpi = 1.5707963267948966192f; /* M_PI / 2.0; */
-  const float sconst = powf((halfpi / (float)nsinc), 2.0f);
-  const float a2 = -0.49670f;
-  const float a4 = 0.03705f;
-  float taper[INTERPOLATE_SINC_NCONV];
-  float ac[INTERPOLATE_SINC_NCONV], ar[INTERPOLATE_SINC_NCONV];
-  float sdx, dx, dy, dxn, dyn, dx2;
-  float ax, ay, px, py;
-  float sum, sumx, sumy;
-  float tmp;
+  const double halfpi = 1.5707963267948966192f; /* M_PI / 2.0; */
+  const double sconst = powf((halfpi / (double)nsinc), 2.0f);
+  const double a2 = -0.49670f;
+  const double a4 = 0.03705f;
+  double taper[INTERPOLATE_SINC_NCONV];
+  double ac[INTERPOLATE_SINC_NCONV], ar[INTERPOLATE_SINC_NCONV];
+  double sdx, dx, dy, dxn, dyn, dx2;
+  double ax, ay, px, py;
+  double sum, sumx, sumy;
+  double tmp;
   integer_t minj, maxj, offj;
   integer_t mink, maxk, offk;
   integer_t nx, ny;
@@ -625,7 +625,7 @@ interpolate_sinc_(PyArrayObject* data,
     for (j = -nsinc; j <= nsinc; ++j) {
       assert(j + nsinc >= 0 && j + nsinc < INTERPOLATE_SINC_NCONV);
 
-      dx2 = sconst * (float)j * (float)j;
+      dx2 = sconst * (double)j * (double)j;
       tmp = powf(1.0f + a2*dx2 + a4*dx2*dx2, 2.0);
       if (errno != 0) {
         driz_error_set_message(error, "pow failed");
@@ -645,8 +645,8 @@ interpolate_sinc_(PyArrayObject* data,
       continue;
     }
 
-    dx = (x[i] - (float)nx) * sinscl;
-    dy = (y[i] - (float)ny) * sinscl;
+    dx = (x[i] - (double)nx) * sinscl;
+    dy = (y[i] - (double)ny) * sinscl;
 
     if (fabsf(dx) < mindx && fabsf(dy) < mindy) {
       index = firstt + (ny - 1) * isize[0] + nx - 1; /* TODO: Base check */
@@ -654,14 +654,14 @@ interpolate_sinc_(PyArrayObject* data,
       continue;
     }
 
-    dxn = 1.0f + (float)nsinc + dx;
-    dyn = 1.0f + (float)nsinc + dy;
+    dxn = 1.0f + (double)nsinc + dx;
+    dyn = 1.0f + (double)nsinc + dy;
     sumx = 0.0f;
     sumy = 0.0f;
     for (j = 0; j < nconv; ++j) {
       /* TODO: These out of range indices also seem to be in Fortran... */
-      ax = dxn - (float)j - 1; /* TODO: Base check */
-      ay = dyn - (float)j - 1; /* TODO: Base check */
+      ax = dxn - (double)j - 1; /* TODO: Base check */
+      ay = dyn - (double)j - 1; /* TODO: Base check */
       assert(ax != 0.0);
       assert(ay != 0.0);
 
@@ -769,9 +769,9 @@ interpolate_sinc_(PyArrayObject* data,
 static int
 interpolate_sinc(const void* state,
                  PyArrayObject* data,
-                 const float x, const float y,
+                 const double x, const double y,
                  /* Output parameters */
-                 float* value,
+                 double* value,
                  struct driz_error_t* error) {
   const struct sinc_param_t* param = (const struct sinc_param_t*)state;
   integer_t   isize[2];
@@ -798,13 +798,13 @@ interpolate_sinc(const void* state,
 static int
 interpolate_lanczos(const void* state,
                     PyArrayObject* data,
-                    const float x, const float y,
+                    const double x, const double y,
                     /* Output parameters */
-                    float* value,
+                    double* value,
                     struct driz_error_t* error UNUSED_PARAM) {
   integer_t ixs, iys, ixe, iye;
   integer_t xoff, yoff;
-  float luty, sum;
+  double luty, sum;
   integer_t nbox;
   integer_t i, j;
   const struct lanczos_param_t* lanczos = (const struct lanczos_param_t*)state;
@@ -834,12 +834,12 @@ interpolate_lanczos(const void* state,
   /* Loop over the box, which is assumed to be scaled appropriately */
   sum = 0.0;
   for (j = iys; j <= iye; ++j) {
-    yoff = (integer_t)(fabs((y - (float)j) / lanczos->space));
+    yoff = (integer_t)(fabs((y - (double)j) / lanczos->space));
     assert(yoff >= 0 && yoff < lanczos->nlut);
 
     luty = lanczos->lut[yoff];
     for (i = ixs; i <= ixe; ++i) {
-      xoff = (integer_t)(fabs((x - (float)i) / lanczos->space));
+      xoff = (integer_t)(fabs((x - (double)i) / lanczos->space));
       assert(xoff >= 0 && xoff < lanczos->nlut);
 
       sum += get_pixel(data, i, j) * lanczos->lut[xoff] * luty;
@@ -877,9 +877,9 @@ int
 doblot(struct driz_param_t* p) {
 
   const size_t nlut = 2048;
-  const float space = 0.01;
+  const double space = 0.01;
   integer_t isize[2], osize[2];
-  float scale2, xo, yo, v;
+  double scale2, xo, yo, v;
   integer_t i, j;
   interp_function* interpolate;
   struct sinc_param_t sinc;
@@ -903,7 +903,7 @@ doblot(struct driz_param_t* p) {
   /* Some interpolation functions need some pre-calculated state */
   if (p->interpolation == interp_lanczos3 || p->interpolation == interp_lanczos5) {
 
-    if ((lanczos.lut = (float*)malloc(nlut * sizeof(float))) == NULL) {
+    if ((lanczos.lut = (double*)malloc(nlut * sizeof(double))) == NULL) {
       driz_error_set_message(p->error, "Out of memory");
       goto doblot_exit_;
     }
@@ -958,8 +958,8 @@ doblot(struct driz_param_t* p) {
       }
 
       /* Check it is on the input image */
-      if (xo >= 0.0 && xo < (float)isize[0] &&
-          yo >= 0.0 && yo < (float)isize[1]) {
+      if (xo >= 0.0 && xo < (double)isize[0] &&
+          yo >= 0.0 && yo < (double)isize[1]) {
 
         double value;
 

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -24,7 +24,7 @@
 
 inline_macro static int
 update_data(struct driz_param_t* p, const integer_t ii, const integer_t jj,
-            const float d, const float vc, const float dow) {
+            const double d, const double vc, const double dow) {
 
   const double vc_plus_dow = vc + dow;
   
@@ -244,7 +244,7 @@ static int
 do_kernel_point(struct driz_param_t* p) {
   integer_t i, j, ii, jj;
   integer_t xbounds[2], ybounds[2], osize[2];
-  float scale2, vc, d, dow;
+  double scale2, vc, d, dow;
   integer_t bv;
   int margin;
 
@@ -339,7 +339,7 @@ static int
 do_kernel_tophat(struct driz_param_t* p) {
   integer_t bv, i, j, ii, jj, nhit, nxi, nxa, nyi, nya;
   integer_t xbounds[2], ybounds[2], osize[2];
-  float scale2, pfo, pfo2, vc, d, dow;
+  double scale2, pfo, pfo2, vc, d, dow;
   double xxi, xxa, yyi, yya, ddx, ddy, r2;
   int margin;
   
@@ -462,7 +462,7 @@ static int
 do_kernel_gaussian(struct driz_param_t* p) {
   integer_t bv, i, j, ii, jj, nxi, nxa, nyi, nya, nhit;
   integer_t xbounds[2], ybounds[2], osize[2];
-  float vc, d, dow;
+  double vc, d, dow;
   double gaussian_efac, gaussian_es;
   double pfo, ac,  scale2, xxi, xxa, yyi, yya, w, ddx, ddy, r2, dover;
   const double nsig = 2.5;
@@ -563,7 +563,7 @@ do_kernel_gaussian(struct driz_param_t* p) {
               vc = get_pixel(p->output_counts, ii, jj);
             }
 
-            dow = (float)dover * w;
+            dow = (double)dover * w;
   
             /* If we are create or modifying the context image, we do so
                here. */
@@ -596,13 +596,13 @@ static int
 do_kernel_lanczos(struct driz_param_t* p) {
   integer_t bv, i, j, ii, jj, nxi, nxa, nyi, nya, nhit, ix, iy;
   integer_t xbounds[2], ybounds[2], osize[2];
-  float scale2, vc, d, dow;
+  double scale2, vc, d, dow;
   double pfo, xx, yy, xxi, xxa, yyi, yya, w, dx, dy, dover;
   int kernel_order;
   int margin;
   struct lanczos_param_t lanczos;
   const size_t nlut = 512;
-  const float del = 0.01;
+  const double del = 0.01;
 
   dx = 1.0;
   dy = 1.0;
@@ -612,7 +612,7 @@ do_kernel_lanczos(struct driz_param_t* p) {
   pfo = (double)kernel_order * p->pixel_fraction / p->scale;
   bv = compute_bit_value(p->uuid);
   
-  if ((lanczos.lut = malloc(nlut * sizeof(float))) == NULL) {
+  if ((lanczos.lut = malloc(nlut * sizeof(double))) == NULL) {
     driz_error_set_message(p->error, "Out of memory");
     return driz_error_is_set(p->error);
   }
@@ -703,7 +703,7 @@ do_kernel_lanczos(struct driz_param_t* p) {
             } else {
               vc = get_pixel(p->output_counts, ii, jj);
             }
-            dow = (float)(dover * w);
+            dow = (double)(dover * w);
   
             /* If we are create or modifying the context image, we do so
                here. */
@@ -740,7 +740,7 @@ static int
 do_kernel_turbo(struct driz_param_t* p) {
   integer_t bv, i, j, ii, jj, nxi, nxa, nyi, nya, nhit, iis, iie, jjs, jje;
   integer_t xbounds[2], ybounds[2], osize[2];
-  float vc, d, dow;
+  double vc, d, dow;
   double pfo, scale2, ac;
   double xxi, xxa, yyi, yya, w, dover;
   int margin;
@@ -797,7 +797,7 @@ do_kernel_turbo(struct driz_param_t* p) {
           driz_error_format_message(p->error, "OOB in data[%d,%d]", i, j);
           return 1;
         } else {
-          d = get_pixel(p->data, i, j) * (float)scale2;
+          d = get_pixel(p->data, i, j) * (double)scale2;
         }
 
         /* Scale the weighting mask by the scale factor and inversely by
@@ -834,7 +834,7 @@ do_kernel_turbo(struct driz_param_t* p) {
               } else {
                 vc = get_pixel(p->output_counts, ii, jj);
               }
-              dow = (float)(dover * w);
+              dow = (double)(dover * w);
   
               /* If we are create or modifying the context image,
                  we do so here. */
@@ -871,7 +871,7 @@ int
 do_kernel_square(struct driz_param_t* p) {
   integer_t bv, i, j, ii, jj, min_ii, max_ii, min_jj, max_jj, nhit;
   integer_t xbounds[2], ybounds[2], osize[2];
-  float scale2, vc, d, dow;
+  double scale2, vc, d, dow;
   double dh, jaco, tem, dover, w;
   double xyin[4][2], xyout[2], xout[4], yout[4];
   int margin;
@@ -982,7 +982,7 @@ do_kernel_square(struct driz_param_t* p) {
   
             /* Re-normalise the area overlap using the Jacobian */
             dover /= jaco;
-            dow = (float)(dover * w);
+            dow = (double)(dover * w);
 
             /* Count the hits */
             ++nhit;  

--- a/src/cdrizzleutil.c
+++ b/src/cdrizzleutil.c
@@ -263,10 +263,10 @@ bool2str(bool_t value) {
 */
 void
 create_lanczos_lut(const int kernel_order, const size_t npix,
-                   const float del, float* lanczos_lut) {
+                   const double del, double* lanczos_lut) {
   integer_t i;
-  const float forder = (float)kernel_order;
-  float poff;
+  const double forder = (double)kernel_order;
+  double poff;
 
   assert(lanczos_lut);
   assert(kernel_order < 6);
@@ -275,7 +275,7 @@ create_lanczos_lut(const int kernel_order, const size_t npix,
   lanczos_lut[0] = 1.0;
 
   for (i = 1; i < npix; ++i) {
-    poff = M_PI * (float)i * del;
+    poff = M_PI * (double)i * del;
     if (poff < M_PI * forder) {
       lanczos_lut[i] = sin(poff) / poff * sin(poff / forder) / (poff / forder);
     } else {
@@ -285,7 +285,7 @@ create_lanczos_lut(const int kernel_order, const size_t npix,
 }
 
 void
-put_fill(struct driz_param_t* p, const float fill_value) {
+put_fill(struct driz_param_t* p, const double fill_value) {
   integer_t i, j, osize[2];
 
   assert(p);

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -109,20 +109,20 @@ enum e_interp_t {
 /* Lanczos values */
 struct lanczos_param_t {
   size_t nlut;
-  float* lut;
+  double* lut;
   double sdp;
   integer_t nbox;
-  float space;
-  float misval;
+  double space;
+  double misval;
 };
 
 struct driz_param_t {
   /* Options */
   enum e_kernel_t kernel; /* Kernel shape and size */
   double          pixel_fraction; /* was: PIXFRAC */
-  float           exposure_time; /* Exposure time was: EXPIN */
-  float           weight_scale; /* Weight scale was: WTSCL */
-  float           fill_value; /* Filling was: FILVAL */
+  double          exposure_time; /* Exposure time was: EXPIN */
+  double          weight_scale; /* Weight scale was: WTSCL */
+  double          fill_value; /* Filling was: FILVAL */
   bool_t          do_fill; /* was: FILL */
   enum e_unit_t   in_units; /* CPS / counts was: INCPS, either counts or CPS */
   enum e_unit_t   out_units; /* CPS / counts was: INCPS, either counts or CPS */
@@ -139,10 +139,10 @@ struct driz_param_t {
 
   /* Blotting-specific parameters */
   enum e_interp_t interpolation; /* was INTERP */
-  float ef; 
-  float misval;
-  float sinscl;
-  float kscale;
+  double ef; 
+  double misval;
+  double sinscl;
+  double kscale;
 
   /* Input images */
   PyArrayObject *data; 
@@ -261,21 +261,21 @@ oob_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix) {
 #define oob_pixel(image, xpix, ypix)   0
 #endif
 
-static inline_macro float
+static inline_macro double
 get_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix) {
-  return *(float*) PyArray_GETPTR2(image, ypix, xpix);
+  return *(double*) PyArray_GETPTR2(image, ypix, xpix);
 }
 
-static inline_macro float
+static inline_macro double
 get_pixel_at_pos(PyArrayObject *image, integer_t pos) {
-  float *imptr;
-  imptr = (float *) PyArray_DATA(image);
+  double *imptr;
+  imptr = (double *) PyArray_DATA(image);
   return imptr[pos];
 }
 
 static inline_macro void
 set_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix, double value) {  
-  *(float*) PyArray_GETPTR2(image, ypix, xpix) = value;
+  *(double*) PyArray_GETPTR2(image, ypix, xpix) = value;
   return;
 }
 
@@ -341,10 +341,10 @@ was: FILALU
 */
 void
 create_lanczos_lut(const int kernel_order, const size_t npix,
-                   const float del, float* lanczos_lut);
+                   const double del, double* lanczos_lut);
 
 void
-put_fill(struct driz_param_t* p, const float fill_value);
+put_fill(struct driz_param_t* p, const double fill_value);
 
 /**
  Calculate the refractive index of MgF2 for a given C wavelength (in
@@ -360,11 +360,11 @@ was: WSUMR
 */
 static inline_macro void
 weighted_sum_vectors(const integer_t npix,
-                     const float* a /*[npix]*/, const float w1,
-                     const float* b /*[npix]*/, const float w2,
+                     const double* a /*[npix]*/, const double w1,
+                     const double* b /*[npix]*/, const double w2,
                      /* Output arguments */
-                     float* c /*[npix]*/) {
-  float* c_end = c + npix;
+                     double* c /*[npix]*/) {
+  double* c_end = c + npix;
 
   assert(a);
   assert(b);


### PR DESCRIPTION
These are changes that should switch drizzle's C library from computing in single precision to double precision. The C code currently builds, but with additional warnings (at least on my machine). 

The only changes I made were searching files in `src` and changing `float` declarations to `double` declarations until the code would  build successfully.