### PR TITLE
Fix incorrect drizzling when inwht is 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-1.13.4 (unreleased)
+1.13.4 (2021-12-23)
 ===================
 
 - drizzle ignores the weight of input image pixels when the weight of the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
 1.13.4 (unreleased)
 ===================
 
-
+- drizzle ignores the weight of input image pixels when the weight of the
+  corresponding output pixel (onto which input pixel flux is to be dropped)
+  is zero. [#79]
 
 
 1.13.3 (2021-06-17)

--- a/drizzle/tests/test_drizzle.py
+++ b/drizzle/tests/test_drizzle.py
@@ -257,8 +257,8 @@ def test_zero_input_weight(tmpdir):
     """
     insci = np.ones((200, 400), dtype=np.float32)
     inwht = np.ones((200, 400), dtype=np.float32)
-    inwht[:, 150:153] = 0
-    pixmap = np.rollaxis(np.mgrid[1:201, 1:401][::-1], 0, 3)
+    inwht[:, 150:155] = 0
+    pixmap = np.moveaxis(np.mgrid[1:201, 1:401][::-1], 0, -1)
 
     outsci = np.zeros((210, 410), dtype=np.float32)
     outwht = np.zeros((210, 410), dtype=np.float32)
@@ -278,7 +278,7 @@ def test_zero_input_weight(tmpdir):
         fillstr='INDEF'
     )
 
-    assert np.allclose(np.sum(outsci), 200 * (400 - 3))
+    assert np.allclose(np.sum(outsci), 200 * (400 - 5))
 
 
 def test_square_with_grid(tmpdir):

--- a/drizzle/tests/test_drizzle.py
+++ b/drizzle/tests/test_drizzle.py
@@ -258,27 +258,30 @@ def test_zero_input_weight(tmpdir):
     insci = np.ones((200, 400), dtype=np.float32)
     inwht = np.ones((200, 400), dtype=np.float32)
     inwht[:, 150:155] = 0
+    tflux = np.sum(inwht)
     pixmap = np.moveaxis(np.mgrid[1:201, 1:401][::-1], 0, -1)
 
-    outsci = np.zeros((210, 410), dtype=np.float32)
-    outwht = np.zeros((210, 410), dtype=np.float32)
-    outcon = np.zeros((210, 410), dtype=np.int32)
+    for kernel in ['square', 'point', 'turbo']:
+        # initialize output:
+        outsci = np.zeros((210, 410), dtype=np.float32)
+        outwht = np.zeros((210, 410), dtype=np.float32)
+        outcon = np.zeros((210, 410), dtype=np.int32)
 
-    _vers, nmiss, nskip = cdrizzle.tdriz(
-        insci, inwht, pixmap,
-        outsci, outwht, outcon,
-        uniqid=1,
-        xmin=0, xmax=400,
-        ymin=0, ymax=200,
-        pixfrac=1,
-        kernel='point',
-        in_units='cps',
-        expscale=1,
-        wtscale=1,
-        fillstr='INDEF'
-    )
+        _vers, nmiss, nskip = cdrizzle.tdriz(
+            insci, inwht, pixmap,
+            outsci, outwht, outcon,
+            uniqid=1,
+            xmin=0, xmax=400,
+            ymin=0, ymax=200,
+            pixfrac=1,
+            kernel=kernel,
+            in_units='cps',
+            expscale=1,
+            wtscale=1,
+            fillstr='INDEF'
+        )
 
-    assert np.allclose(np.sum(outsci), 200 * (400 - 5))
+        assert np.allclose(np.sum(outsci), tflux)
 
 
 def test_square_with_grid(tmpdir):

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -26,10 +26,13 @@ inline_macro static int
 update_data(struct driz_param_t* p, const integer_t ii, const integer_t jj,
             const float d, const float vc, const float dow) {
 
-  const double vc_plus_dow = vc + dow;
+  double vc_plus_dow;
   
-  /* Just a simple calculation without logical tests */
-  if (vc == 0.0) {
+  if (dow == 0.0f) return 0;
+  
+  vc_plus_dow = vc + dow;
+  
+  if (vc == 0.0f) {
     if (oob_pixel(p->output_data, ii, jj)) {
       driz_error_format_message(p->error, "OOB in output_data[%d,%d]", ii, jj);
       return 1;
@@ -37,7 +40,7 @@ update_data(struct driz_param_t* p, const integer_t ii, const integer_t jj,
       set_pixel(p->output_data, ii, jj, d);
     }
 
-  } else if (vc_plus_dow != 0.0) {
+  } else {
     if (oob_pixel(p->output_data, ii, jj)) {
       driz_error_format_message(p->error, "OOB in output_data[%d,%d]", ii, jj);
       return 1;


### PR DESCRIPTION
This PR fixes a bug in the C code of the core drizzle algorithm due to which flux from the input image could be dropped onto the output (resampled) image even though those input pixels have zero weights.

The same bug is present in the C code in the `drizzlepac`.

Fixes https://github.com/spacetelescope/jwst/issues/6167