### PR TITLE
JP-2702: Fix image shifts with square kernel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@
 
 - Pin astropy min version to 5.0.4. [#81]
 
+- Fix a bug in the interpolation algorithm used by the 'square' kernel that
+  resulted in shifts of the resampled image typically by 0.5 pixels compared
+  to the location indicated by the WCS. [#83]
+
 1.13.4 (2021-12-23)
 ===================
 


### PR DESCRIPTION
Closes #82
Resolves https://jira.stsci.edu/browse/JP-2702

This is an alternative PR to #82 and fixes the interpolation algorithm used by the square kernel. First, the interpolation itself is now bilinear. Second, the algorithm for finding vertices of the interpolation rectangle (`interpolation_bounds()`) was replaced with a simplified version `interpolation_starting_point()` that does not have the

> Bounce around the starting point until we find four valid points on the line

logic. That is, if one of the vertices has an `NaN` value then interpolation result will also be an `NaN`. I do not think this should cause problems but it should be checked with images that have WCS with bounding boxes and whose WCS produces NaNs outside of bounding boxes.

My initial testing shows that this PR solves the issue. However, as I mentioned above, it should be tested with WCS that can give NaN outside of the bounding box and also it should be tested with various pixfrac ... parameters.