### PR TITLE
Fix incorrect identification of lines to be skipped

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,17 @@
 Release Notes
 =============
 
-.. 1.13.7 (unreleased)
+.. 1.13.8 (unreleased)
    ===================
+
+
+1.13.7 (2023-02-09)
+===================
+
+- Fixed a bug in identification of lines in input images that should be skipped
+  because they would not map to the output image. This bug may result in large
+  chunks of input image incorrectly missing from the resampled image. [#89]
+
 
 1.13.6 (2021-08-05)
 ===================
@@ -23,6 +32,7 @@ Release Notes
 - Fix a bug in the interpolation algorithm used by the 'square' kernel that
   resulted in shifts of the resampled image typically by 0.5 pixels compared
   to the location indicated by the WCS. [#83]
+
 
 1.13.4 (2021-12-23)
 ===================

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -104,13 +104,18 @@ shrink_segment(struct segment *self,
                PyArrayObject *array,
                int (*is_bad_value)(PyArrayObject *, int, int)) {
 
-  int i, j, imin, imax, jmin, jmax;
+  int i, j, imin, imax, jmin, jmax, i1, i2, j1, j2;
 
   imin = self->point[1][0];
   jmin = self->point[1][1];
 
-  for (j = self->point[0][1]; j < self->point[1][1]; ++j) {
-    for (i = self->point[0][0]; i < self->point[1][0]; ++ i) {
+  j1 = (int) ceil(self->point[1][1]);
+  j2 = (int) self->point[0][1];
+  i1 = (int) ceil(self->point[1][0]);
+  i2 = (int) self->point[0][0];
+
+  for (j = j2; j < j1; ++j) {
+    for (i = i2; i < i1; ++i) {
       if (! is_bad_value(array, i, j)) {
         if (i < imin) {
           imin = i;
@@ -125,9 +130,8 @@ shrink_segment(struct segment *self,
 
   imax = self->point[0][0];
   jmax = self->point[0][1];
-
-  for (j = self->point[1][1]; j > self->point[0][1]; --j) {
-    for (i = self->point[1][0]; i > self->point[0][0]; -- i) {
+  for (j = j1; j > j2; --j) {
+    for (i = i1; i > i2; --i) {
       if (! is_bad_value(array, i-1, j-1)) {
         if (i > imax) {
           imax = i;
@@ -139,7 +143,6 @@ shrink_segment(struct segment *self,
       }
     }
   }
-
   initialize_segment(self, imin, jmin, imax, jmax);
   self->invalid = imin >= imax || jmin >= jmax;
   return;


### PR DESCRIPTION
It was reported (help desk ticket INC0186717) that under some circumstances, some parts of input images may be missing in the resampled output images. This occurs when a vertex of the input image is outside of the resampled image. I traced this to be a bug in how algorithm identifies which lines in the input images are completely outside of the output image.

The image below illustrates the issue. Notice missing data in the top-right corner:

![missing-image-data](https://user-images.githubusercontent.com/5985250/217598260-034b7535-8073-4c31-939e-845f99ee53d3.gif)

This PR fixes the issue.
