### PR TITLE
add ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+version: 2
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  version: "3.8"
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: "3.8"
+  version: "3.9"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
Currently, documentation is hosted on GitHub Pages at https://spacetelescope.github.io/drizzle/

This PR adds a ReadTheDocs configuration to build on RTD. Once the `.readthedocs.yaml` file is put in the main branch we should be able to create a RTD instance on https://readthedocs.org