### PR TITLE
drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
     with:
       envs: |
         - linux: test-xdist
-          python-version: 3.8
-        - linux: test-xdist
           python-version: 3.9
         - linux: test-xdist
           python-version: 3.10

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,8 +3,16 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: mambaforge-4.10
+
+conda:
+  environment: docs/rtd_environment.yaml
+
 python:
-  version: "3.8"
+  system_packages: false
   install:
     - method: pip
       path: .

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,0 +1,8 @@
+name: rtd311
+channels:
+ - conda-forge
+ - defaults
+dependencies:
+ - python=3.11
+ - pip
+ - graphviz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "drizzle"
 description = "A package for combining dithered images into a single image"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "STScI", email = "help@stsci.edu" },
 ]


### PR DESCRIPTION
Numpy is imminently dropping support for Python 3.8