### PR TITLE
test against pre-built binaries of `astropy` and `numpy`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ deps =
     xdist: pytest-xdist
     cov: pytest-cov
     devdeps: astropy>=0.0.dev0
+    devdeps: numpy>=0.0.dev0
 commands_pre =
     pip freeze
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
     ci_watson
     xdist: pytest-xdist
     cov: pytest-cov
-    devdeps: git+https://github.com/astropy/astropy
+    devdeps: astropy>=0.0.dev0
 commands_pre =
     pip freeze
 commands =


### PR DESCRIPTION
Resolves [SCSB-69](https://jira.stsci.edu/browse/SCSB-69)

uses the `pre` wheels of `astropy` and `numpy` in the `devdeps` tests