### PR TITLE
revert astropy prerelease wheel spec and use nightly Scipy wheel index

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,14 +37,15 @@ description =
     cov: with coverage
     xdist: using parallel processing
 package = editable
+set_env =
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 deps =
     pytest
     ci_watson
     xdist: pytest-xdist
     cov: pytest-cov
-    devdeps: astropy>=0.0.dev0
-    devdeps: numpy>=0.0.dev0
 commands_pre =
+    devdeps: pip install numpy>=0.0.dev0 git+https://github.com/astropy/astropy -U --upgrade-strategy eager
     pip freeze
 commands =
     pytest \

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ description =
     xdist: using parallel processing
 package = editable
 set_env =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
 deps =
     pytest
     ci_watson


### PR DESCRIPTION
This PR addresses @WilliamJamieson's comments in https://github.com/spacetelescope/romancal/pull/695#discussion_r1189078751; the change to the Astropy dev spec in #100 didn't actually accomplish anything, and `numpy` wheels are hosted at a different index URL
