### PR TITLE
[CI] add Windows job and rename `toxenv`s to include Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           python-version: 3.11
         - macos: test-xdist
           python-version: 3.11
+        - windows: test-xdist
         - linux: test-devdeps-xdist
         - linux: test-xdist-cov
           coverage: codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,17 +27,12 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
-        - linux: test-xdist
-          python-version: 3.8
-        - linux: test-xdist
-          python-version: 3.9
-        - linux: test-xdist
-          python-version: 3.10
-        - linux: test-xdist
-          python-version: 3.11
-        - macos: test-xdist
-          python-version: 3.11
-        - windows: test-xdist
-        - linux: test-devdeps-xdist
-        - linux: test-xdist-cov
+        - linux: py38-xdist
+        - linux: py39-xdist
+        - linux: py310-xdist
+        - linux: py311-xdist
+        - macos: py311-xdist
+        - windows: py311-xdist
+        - linux: py311-devdeps-xdist
+        - linux: py311-xdist-cov
           coverage: codecov


### PR DESCRIPTION
closes #38 
<img width="274" alt="image" src="https://github.com/spacetelescope/drizzle/assets/16024299/a7f4df89-d903-4e46-b0dc-623819179ccc">
