### PR TITLE
Fix failing tests after interpolation bug fix

### DIFF
--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -517,13 +517,23 @@ FCT_BGN_FN(utest_cdrizzle)
 
             p = setup_parameters();
             stretch_pixmap(p, 1000.0);
-            nan_pixel(p, 3, 5);
 
             xyin[0] = 3.25;
             xyin[1] = 5.0;
 
             status = map_point(p->pixmap, xyin, xyout);
+            fct_chk_int_return_status(status, 0);
+
+            fct_chk_eq_dbl(xyout[0], 3.25);
+            fct_chk_eq_dbl(xyout[1], 5000.0);
+
+            nan_pixel(p, 3, 5);
+
+            status = map_point(p->pixmap, xyin, xyout);
             fct_chk_int_return_status(status, 1);
+
+            fct_chk_neq_int(xyout[0], xyout[0]);
+            fct_chk_neq_int(xyout[1], xyout[1]);
 
             teardown_parameters(p);
         }
@@ -536,13 +546,22 @@ FCT_BGN_FN(utest_cdrizzle)
             struct driz_param_t *p;
 
             p = setup_parameters();
-            nan_pixel(p, 0, 5);
 
             xyin[0] = 0.25;
             xyin[1] = 5.0;
 
             status = map_point(p->pixmap, xyin, xyout);
+
+            fct_chk_int_return_status(status, 0);
+            fct_chk_eq_dbl(xyout[0], 0.25);
+            fct_chk_eq_dbl(xyout[1], 5.0);
+
+            nan_pixel(p, 0, 5);
+            status = map_point(p->pixmap, xyin, xyout);
+
             fct_chk_int_return_status(status, 1);
+            fct_chk_neq_int(xyout[0], xyout[0]);
+            fct_chk_neq_int(xyout[1], xyout[1]);
 
             teardown_parameters(p);
         }


### PR DESCRIPTION
#83 fixed a bug in the interpolation algorithm but it did not update unit tests. This PR fixes those unit tests.

Closes #88