### PR TITLE
Fix incorrect overlap computations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ _build
 # Pycharm editor project files
 .idea
 
+# VSCode
+.vscode
+
 # Packages/installer info
 *.egg
 *.eggs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,18 @@
 Release Notes
 =============
 
-.. 1.13.8 (unreleased)
+.. 1.14.1 (unreleased)
    ===================
+
+
+
+1.14.0 (unreleased)
+===================
+
+- Fixed a bug in how drizzle would compute overlaps between input images and
+  the output image. Due to this bug large parts of input image data may be
+  missing in the resampled data when output image size was set by the
+  caller to be smaller than size needed to hold *all* image data. [#104]
 
 
 1.13.7 (2023-02-09)

--- a/drizzle/tests/test_cdrizzle.py
+++ b/drizzle/tests/test_cdrizzle.py
@@ -19,8 +19,6 @@ def test_cdrizzle():
     output_counts = np.zeros((size,size), dtype='float32')
     output_context = np.zeros((size,size), dtype='int32')
 
-    print(f"test_cdrizzle: output_data.shape={output_data.shape}")
-
     cdrizzle.test_cdrizzle(data, weights, pixmap,
                            output_data, output_counts,
                            output_context)

--- a/drizzle/tests/test_cdrizzle.py
+++ b/drizzle/tests/test_cdrizzle.py
@@ -19,6 +19,8 @@ def test_cdrizzle():
     output_counts = np.zeros((size,size), dtype='float32')
     output_context = np.zeros((size,size), dtype='int32')
 
+    print(f"test_cdrizzle: output_data.shape={output_data.shape}")
+
     cdrizzle.test_cdrizzle(data, weights, pixmap,
                            output_data, output_counts,
                            output_context)

--- a/drizzle/tests/test_overlap_calc.py
+++ b/drizzle/tests/test_overlap_calc.py
@@ -1,0 +1,205 @@
+import os
+import pytest
+from math import sqrt
+
+import numpy as np
+
+from drizzle.cdrizzle import intersect_convex_polygons, invert_pixmap
+
+
+TEST_DIR = os.path.abspath(os.path.dirname(__file__))
+DATA_DIR = os.path.join(TEST_DIR, 'data')
+SQ2 = 1.0 / sqrt(2.0)
+
+
+def _coord_mapping(xin, yin):
+    crpix = (289, 348)  # center of distortions
+    shift = (1000, 1000)
+    rmat = 2.0 * np.array([[0.78103169, 0.66712321], [-0.63246699, 0.74091539]])
+    x = xin - crpix[0]
+    y = yin - crpix[1]
+
+    # add non-linear distortions
+    x += 2.4e-6 * x**2 - 1.0e-7 * x * y + 3.1e-6 * y**2
+    y += 1.2e-6 * x**2 - 2.0e-7 * x * y + 1.1e-6 * y**2
+
+    x, y = np.dot(rmat, [x, y])
+    x += shift[0]
+    y += shift[1]
+
+    return x, y
+
+
+def _roll_vertices(polygon, n=1):
+    n = n % len(polygon)
+    return polygon[n:] + polygon[:n]
+
+
+def test_invert_pixmap():
+    yin, xin = np.indices((1000, 1200), dtype=float)
+    xin = xin.flatten()
+    yin = yin.flatten()
+
+    xout, yout = _coord_mapping(xin, yin)
+    xout = xout.reshape((1000, 1200))
+    yout = yout.reshape((1000, 1200))
+    pixmap = np.dstack([xout, yout])
+
+
+    test_coords = [
+        (300, 600),
+        (0, 0),
+        (1199, 999),
+        (0, 999),
+        (1199, 0),
+        (200, 0),
+        (0, 438),
+        (1199, 432),
+    ]
+
+    for xr, yr in test_coords:
+        xout_t, yout_t = _coord_mapping(xr, yr)
+        xyin = invert_pixmap(pixmap, [xout_t, yout_t])
+        assert np.allclose(xyin, [xr, yr], atol=0.05)
+
+
+def test_poly_intersection_with_self():
+    p = [(0, 0), (1, 0), (1, 1), (0, 1)]
+
+    for k in range(4):
+        q = _roll_vertices(p, k)
+
+        pq = intersect_convex_polygons(p, q)
+        assert pq == p
+
+        pq = intersect_convex_polygons(q, p)
+        assert pq == q
+
+
+@pytest.mark.parametrize(
+    'shift', [(0.25, 0.1), (-0.25, -0.1), (-0.25, 0.1), (0.25, -0.1)],
+)
+def test_poly_intersection_shifted(shift):
+    p = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    sx, sy = shift
+    pq_ref = sorted(
+        [
+            (max(0, sx), max(0, sy)),
+            (min(1, sx + 1), max(0, sy)),
+            (min(1, sx + 1), min(1, sy + 1)),
+            (max(0, sx), min(1, sy + 1)),
+        ],
+    )
+
+    for k in range(4):
+        q = [(x + sx, y + sy) for x, y in p]
+        q = _roll_vertices(q, k)
+        pq = intersect_convex_polygons(p, q)
+        assert np.allclose(sorted(pq), pq_ref)
+
+
+def test_poly_intersection_rotated45():
+    p = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    q = [(0, 0), (SQ2, -SQ2), (2.0 * SQ2, 0), (SQ2, SQ2)]
+    pq_ref = [(0, 0), (SQ2, SQ2), (1, 0), (1, SQ2 / (1.0 + SQ2))]
+
+    for k in range(4):
+        q = _roll_vertices(q, k)
+        pq = intersect_convex_polygons(p, q)
+        assert np.allclose(sorted(pq), pq_ref)
+
+
+@pytest.mark.parametrize(
+    'axis', [0, 1],
+)
+def test_poly_intersection_flipped_axis(axis):
+    p = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    # (flipped wrt X-axis or Y-axis). Also change direction:
+    if axis == 0:
+        q = [(i, -j) for i, j in p][::-1]
+    else:
+        q = [(-i, j) for i, j in p][::-1]
+
+    for k in range(4):
+        q = _roll_vertices(q, k)
+        pq = intersect_convex_polygons(p, q)
+        assert len(pq) <= 2
+        assert (0, 0) in pq or (1, 0) in pq or (0, 1) in pq
+
+def test_poly_intersection_reflect_origin():
+    p = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    # reflect wrt origin:
+    q = [(-i, -j) for i, j in p]
+
+    for k in range(4):
+        q = _roll_vertices(q, k)
+        pq = intersect_convex_polygons(p, q)
+        assert pq ==[(0, 0)]
+
+
+@pytest.mark.parametrize(
+    'q,small',
+    [
+        ([(0.1, 0.1), (0.9, 0.1), (0.9, 0.9), (0.1, 0.9)], True),
+        ([(0.0, 0.0), (1.0, 0.0), (1.0, 0.4), (0.0, 0.4)], True),
+        ([(-0.1, -0.1), (1.1, -0.1), (1.1, 1.1), (-0.1, 1.1)], False),
+    ],
+)
+def test_poly_includes_the_other(q, small):
+    p = [(0, 0), (1, 0), (1, 1), (0, 1)]
+
+    for k in range(4):
+        q = _roll_vertices(q, k)
+        pq = intersect_convex_polygons(p, q)
+        qp = intersect_convex_polygons(q, p)
+
+        if small:
+            assert pq == q
+            assert qp == q
+        else:
+            assert pq == p
+            assert qp == p
+
+
+@pytest.mark.parametrize(
+    'q',
+    [
+        [(0, 0), (1, 0), (0.5, 0.6)],
+        [(0.1, 0), (0.9, 0), (0.5, 0.6)],
+    ],
+)
+def test_poly_triangle_common_side(q):
+    p = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    sq = sorted(q)
+
+    for k in range(3):
+        q = _roll_vertices(q, k)
+        pq = intersect_convex_polygons(p, q)
+        assert np.allclose(sq, sorted(pq))
+
+
+def test_poly_triangle_common_side_lg():
+    p = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    q = [(-0.1, 0), (1.1, 0), (0.5, 0.6)]
+    ref_pq = [(0, 0), (0, 0.1), (0.5, 0.6), (1, 0), (1, 0.1)]
+
+    for k in range(3):
+        q = _roll_vertices(q, k)
+        pq = intersect_convex_polygons(p, q)
+        assert np.allclose(ref_pq, sorted(pq))
+
+
+def test_poly_intersection_with_self_extra_vertices():
+    p = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    p_ref = [(0, 0), (0, 1), (1, 0), (1, 1)]
+    # Q is same as P with extra vertices places along P's edges
+    q = [(0, 0), (0.5, 0), (1, 0), (1, 0.4), (1, 1), (0.7, 1), (0, 1), (0, 0.2)]
+
+    for k in range(4):
+        q = _roll_vertices(q, k)
+
+        pq = intersect_convex_polygons(p, q)
+        assert sorted(pq) == p_ref
+
+        pq = intersect_convex_polygons(q, p)
+        assert sorted(pq) == p_ref

--- a/drizzle/tests/test_overlap_calc.py
+++ b/drizzle/tests/test_overlap_calc.py
@@ -59,7 +59,7 @@ def test_invert_pixmap():
 
     for xr, yr in test_coords:
         xout_t, yout_t = _coord_mapping(xr, yr)
-        xyin = invert_pixmap(pixmap, [xout_t, yout_t])
+        xyin = invert_pixmap(pixmap, [xout_t, yout_t], [[-0.5, 1199.5], [-0.5, 999.5]])
         assert np.allclose(xyin, [xr, yr], atol=0.05)
 
 
@@ -95,6 +95,29 @@ def test_poly_intersection_shifted(shift):
         q = [(x + sx, y + sy) for x, y in p]
         q = _roll_vertices(q, k)
         pq = intersect_convex_polygons(p, q)
+        assert np.allclose(sorted(pq), pq_ref)
+
+
+@pytest.mark.parametrize(
+    'shift', [(0, 70), (70, 0), (0, -70), (-70, 0)],
+)
+def test_poly_intersection_shifted_large(shift):
+    p = [(-0.5, -0.5), (99.5, -0.5), (99.5, 99.5), (-0.5, 99.5)]
+    sx, sy = shift
+    pq_ref = sorted(
+        [
+            (max(-0.5, -0.5 + sx), max(-0.5, -0.5 + sy)),
+            (min(99.5, 99.5 + sx), max(-0.5, -0.5 + sy)),
+            (min(99.5, 99.5 + sx), min(99.5, 99.5 + sy)),
+            (max(-0.5, -0.5 + sx), min(99.5, 99.5 + sy)),
+        ],
+    )
+
+    for k in range(4):
+        q = [(x + sx, y + sy) for x, y in p]
+        q = _roll_vertices(q, k)
+        pq = intersect_convex_polygons(p, q)
+        assert len(pq) == 4
         assert np.allclose(sorted(pq), pq_ref)
 
 

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -48,6 +48,61 @@ scale_image(PyArrayObject *image, double scale_factor) {
  * Top level function for drizzling, interfaces with python code
  */
 
+int
+shrink_image_section(PyArrayObject *pixmap, int *xmin, int *xmax,
+                     int *ymin, int *ymax) {
+    int i, j, imin, imax, jmin, jmax, i1, i2, j1, j2;
+    double *pv;
+
+    j1 = *ymin;
+    j2 = *ymax;
+    i1 = *xmin;
+    i2 = *xmax;
+
+    imin = i2;
+    jmin = j2;
+
+    for (j = j1; j <= j2; ++j) {
+        for (i = i1; i <= i2; ++i) {
+            pv = (double *) PyArray_GETPTR3(pixmap, j, i, 0);
+            if (!(npy_isnan(pv[0]) || npy_isnan(pv[1]))) {
+                if (i < imin) {
+                    imin = i;
+                }
+                if (j < jmin) {
+                    jmin = j;
+                }
+                break;
+            }
+        }
+    }
+
+    imax = imin;
+    jmax = jmin;
+
+    for (j = j2; j >= j1; --j) {
+        for (i = i2; i >= i1; --i) {
+            pv = (double *) PyArray_GETPTR3(pixmap, j, i, 0);
+            if (!(npy_isnan(pv[0]) || npy_isnan(pv[1]))) {
+                if (i > imax) {
+                    imax = i;
+                }
+                if (j > jmax) {
+                    jmax = j;
+                }
+                break;
+            }
+        }
+    }
+
+    *xmin = imin;
+    *xmax = imax;
+    *ymin = jmin;
+    *ymax = jmax;
+
+    return (imin >= imax || jmin >= jmax);
+}
+
 static PyObject *
 tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
 {
@@ -166,8 +221,14 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
   /* Set the area to be processed */
 
   get_dimensions(img, isize);
-  if (xmax == 0) xmax = isize[0];
-  if (ymax == 0) ymax = isize[1];
+  if (xmax == 0 || xmax >= isize[0]) xmax = isize[0] - 1;
+  if (ymax == 0 || ymax >= isize[1]) ymax = isize[1] - 1;
+
+  //if (shrink_image_section(map, &xmin, &xmax, &ymin, &ymax)) {
+    //driz_error_set_message(&error,
+        //"No or too few valid pixels in the pixel map.");
+    //goto _exit;
+  //}
 
   /* Convert strings to enumerations */
 
@@ -440,87 +501,107 @@ test_cdrizzle(PyObject *self, PyObject *args)
 static PyObject *
 invert_pixmap_wrap(PyObject *self, PyObject *args)
 {
-  PyObject *pixmap, *xyout;
-  PyArrayObject *xyout_arr, *pixmap_arr;
-  double *xyin;
-  npy_intp xyin_dim = 2;
+    PyObject *pixmap, *xyout, *bbox;
+    PyArrayObject *xyout_arr, *pixmap_arr, *bbox_arr;
+    struct driz_param_t par;
+    double *xyin;
+    npy_intp *ndim, xyin_dim = 2;
 
-  xyin = (double *) malloc(2 * sizeof(double));
+    xyin = (double *) malloc(2 * sizeof(double));
 
-  if (!PyArg_ParseTuple(args,"OO:invpixmap", &pixmap, &xyout)) {
-    return NULL;
-  }
+    if (!PyArg_ParseTuple(args,"OOO:invpixmap", &pixmap, &xyout, &bbox)) {
+      return NULL;
+    }
 
-  xyout_arr = (PyArrayObject *)PyArray_ContiguousFromAny(xyout, NPY_DOUBLE, 1, 1);
-  if (!xyout_arr) {
-    return PyErr_Format(gl_Error, "Invalid xyout array.");
-  }
+    xyout_arr = (PyArrayObject *)PyArray_ContiguousFromAny(xyout, NPY_DOUBLE, 1, 1);
+    if (!xyout_arr) {
+      return PyErr_Format(gl_Error, "Invalid xyout array.");
+    }
 
-  pixmap_arr = (PyArrayObject *)PyArray_ContiguousFromAny(pixmap, NPY_DOUBLE, 3, 3);
-  if (!pixmap_arr) {
-    return PyErr_Format(gl_Error, "Invalid pixmap.");
-  }
+    pixmap_arr = (PyArrayObject *)PyArray_ContiguousFromAny(pixmap, NPY_DOUBLE, 3, 3);
+    if (!pixmap_arr) {
+      return PyErr_Format(gl_Error, "Invalid pixmap.");
+    }
 
-  if (invert_pixmap(pixmap_arr, (double *)PyArray_DATA(xyout_arr), xyin)) {
-      return Py_BuildValue("");
-  }
+    par.pixmap = pixmap_arr;
+    ndim = PyArray_DIMS(pixmap_arr);
 
-  PyArrayObject *arr = (PyArrayObject *)PyArray_SimpleNewFromData(
-      1, &xyin_dim,  NPY_DOUBLE, xyin);
+    if (bbox == Py_None) {
+        par.xmin = -0.5;
+        par.xmax = ndim[1] - 0.5;
+        par.ymin = -0.5;
+        par.ymax = ndim[0] - 0.5;
+    } else {
+        bbox_arr = (PyArrayObject *)PyArray_ContiguousFromAny(bbox, NPY_DOUBLE, 2, 2);
+        if (!bbox_arr) {
+          return PyErr_Format(gl_Error, "Invalid input bounding box.");
+        }
+        par.xmin = *(double*) PyArray_GETPTR2(bbox_arr, 0, 0);
+        par.xmax = *(double*) PyArray_GETPTR2(bbox_arr, 0, 1);
+        par.ymin = *(double*) PyArray_GETPTR2(bbox_arr, 1, 0);
+        par.ymax = *(double*) PyArray_GETPTR2(bbox_arr, 1, 1);
+    }
 
-  PyArray_ENABLEFLAGS(arr, NPY_ARRAY_OWNDATA);
+    if (invert_pixmap(&par, (double *)PyArray_DATA(xyout_arr), xyin)) {
+        return Py_BuildValue("");
+    }
 
-  return Py_BuildValue("N", arr);
+    PyArrayObject *arr = (PyArrayObject *)PyArray_SimpleNewFromData(
+        1, &xyin_dim,  NPY_DOUBLE, xyin);
+
+    PyArray_ENABLEFLAGS(arr, NPY_ARRAY_OWNDATA);
+
+    return Py_BuildValue("N", arr);
 }
 
 
 static PyObject *
 intersect_convex_polygons_wrap(PyObject *self, PyObject *args)
 {
-  int k;
-  PyObject *pin, *qin;
-  PyArrayObject *pin_arr, *qin_arr;
-  struct polygon p, q, pq;
-  PyObject *list, *tuple;
+    int k;
+    PyObject *pin, *qin;
+    PyArrayObject *pin_arr, *qin_arr;
+    struct polygon p, q, pq;
+    PyObject *list, *tuple;
 
-  if (!PyArg_ParseTuple(args,"OO:intersect_convex_polygons", &pin, &qin)) {
-    return NULL;
-  }
+    if (!PyArg_ParseTuple(args,"OO:intersect_convex_polygons", &pin, &qin)) {
+      return NULL;
+    }
 
-  pin_arr = (PyArrayObject *)PyArray_ContiguousFromAny(pin, NPY_DOUBLE, 2, 2);
-  if (!pin_arr) {
-    return PyErr_Format(gl_Error, "Invalid P.");
-  }
+    pin_arr = (PyArrayObject *)PyArray_ContiguousFromAny(pin, NPY_DOUBLE, 2, 2);
+    if (!pin_arr) {
+      return PyErr_Format(gl_Error, "Invalid P.");
+    }
 
-  qin_arr = (PyArrayObject *)PyArray_ContiguousFromAny(qin, NPY_DOUBLE, 2, 2);
-  if (!qin_arr) {
-    return PyErr_Format(gl_Error, "Invalid Q.");
-  }
+    qin_arr = (PyArrayObject *)PyArray_ContiguousFromAny(qin, NPY_DOUBLE, 2, 2);
+    if (!qin_arr) {
+      return PyErr_Format(gl_Error, "Invalid Q.");
+    }
 
-  p.npv = PyArray_SHAPE(pin_arr)[0];
-  for (k = 0; k < p.npv; ++k) {
-      p.v[k].x = *((double *) PyArray_GETPTR2(pin_arr, k, 0));
-      p.v[k].y = *((double *) PyArray_GETPTR2(pin_arr, k, 1));
-  }
+    p.npv = PyArray_SHAPE(pin_arr)[0];
+    for (k = 0; k < p.npv; ++k) {
+        p.v[k].x = *((double *) PyArray_GETPTR2(pin_arr, k, 0));
+        p.v[k].y = *((double *) PyArray_GETPTR2(pin_arr, k, 1));
+    }
 
-  q.npv = PyArray_SHAPE(qin_arr)[0];
-  for (k = 0; k < q.npv; ++k) {
-      q.v[k].x = *((double *) PyArray_GETPTR2(qin_arr, k, 0));
-      q.v[k].y = *((double *) PyArray_GETPTR2(qin_arr, k, 1));
-  }
+    q.npv = PyArray_SHAPE(qin_arr)[0];
+    for (k = 0; k < q.npv; ++k) {
+        q.v[k].x = *((double *) PyArray_GETPTR2(qin_arr, k, 0));
+        q.v[k].y = *((double *) PyArray_GETPTR2(qin_arr, k, 1));
+    }
 
-  intersect_convex_polygons(&p, &q, &pq);
+    intersect_convex_polygons(&p, &q, &pq);
 
-  list = PyList_New(pq.npv);
+    list = PyList_New(pq.npv);
 
-  for (k = 0; k < pq.npv; ++k) {
-      tuple = PyTuple_New(2);
-      PyTuple_SetItem(tuple, 0, PyFloat_FromDouble(pq.v[k].x));
-      PyTuple_SetItem(tuple, 1, PyFloat_FromDouble(pq.v[k].y));
-      PyList_SetItem(list, k, tuple);
-  }
+    for (k = 0; k < pq.npv; ++k) {
+        tuple = PyTuple_New(2);
+        PyTuple_SetItem(tuple, 0, PyFloat_FromDouble(pq.v[k].x));
+        PyTuple_SetItem(tuple, 1, PyFloat_FromDouble(pq.v[k].y));
+        PyList_SetItem(list, k, tuple);
+    }
 
-  return Py_BuildValue("N", list);
+    return Py_BuildValue("N", list);
 }
 
 
@@ -535,7 +616,7 @@ static struct PyMethodDef cdrizzle_methods[] = {
     "tblot(image, output, xmin, xmax, ymin, ymax, scale, kscale, interp, ef, misval, sinscl, pixmap)"},
     {"test_cdrizzle", test_cdrizzle, METH_VARARGS,
     "test_cdrizzle(data, weights, pixmap, output_data, output_counts)"},
-    {"invert_pixmap", invert_pixmap_wrap, METH_VARARGS, "invert_pixmap(pixmap, xyout)"},
+    {"invert_pixmap", invert_pixmap_wrap, METH_VARARGS, "invert_pixmap(pixmap, xyout, bbox)"},
     {"intersect_convex_polygons", intersect_convex_polygons_wrap, METH_VARARGS, "intersect_convex_polygons(p, q)"},
     {NULL,        NULL}        /* sentinel */
 };

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -449,7 +449,7 @@ invert_pixmap_wrap(PyObject *self, PyObject *args)
     PyObject *pixmap, *xyout, *bbox;
     PyArrayObject *xyout_arr, *pixmap_arr, *bbox_arr;
     struct driz_param_t par;
-    double *xyin;
+    double *xy, *xyin;
     npy_intp *ndim, xyin_dim = 2;
 
     xyin = (double *) malloc(2 * sizeof(double));
@@ -487,7 +487,9 @@ invert_pixmap_wrap(PyObject *self, PyObject *args)
         par.ymax = *(double*) PyArray_GETPTR2(bbox_arr, 1, 1);
     }
 
-    if (invert_pixmap(&par, (double *)PyArray_DATA(xyout_arr), xyin)) {
+    xy = (double *)PyArray_DATA(xyout_arr);
+
+    if (invert_pixmap(&par, xy[0], xy[1], &xyin[0], &xyin[1])) {
         return Py_BuildValue("");
     }
 

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -286,14 +286,14 @@ do_kernel_point(struct driz_param_t* p) {
         }
 
         for (i = xmin; i <= xmax; ++i) {
-            double xyout[2];
+            double ox, oy;
 
-            if (map_pixel(p->pixmap, i, j, xyout)) {
+            if (map_pixel(p->pixmap, i, j, &ox, &oy)) {
               ++ p->nmiss;
 
             } else {
-                ii = fortran_round(xyout[0]);
-                jj = fortran_round(xyout[1]);
+                ii = fortran_round(ox);
+                jj = fortran_round(oy);
 
                 /* Check it is on the output image */
                 if (ii < 0 || ii >= osize[0] || jj < 0 || jj >= osize[1]) {
@@ -378,17 +378,17 @@ do_kernel_tophat(struct driz_param_t* p) {
         }
 
         for (i = xmin; i <= xmax; ++i) {
-            double xyout[2];
+            double ox, oy;
 
-            if (map_pixel(p->pixmap, i, j, xyout)) {
+            if (map_pixel(p->pixmap, i, j, &ox, &oy)) {
                 nhit = 0;
 
             } else {
                 /* Offset within the subset */
-                xxi = xyout[0] - pfo;
-                xxa = xyout[0] + pfo;
-                yyi = xyout[1] - pfo;
-                yya = xyout[1] + pfo;
+                xxi = ox - pfo;
+                xxa = ox + pfo;
+                yyi = oy - pfo;
+                yya = oy + pfo;
 
                 nxi = MAX(fortran_round(xxi), 0);
                 nxa = MIN(fortran_round(xxa), osize[0]-1);
@@ -410,11 +410,11 @@ do_kernel_tophat(struct driz_param_t* p) {
 
                 /* Loop over output pixels which could be affected */
                 for (jj = nyi; jj <= nya; ++jj) {
-                    ddy = xyout[1]- (double)jj;
+                    ddy = oy - (double)jj;
 
                     /* Check it is on the output image */
                     for (ii = nxi; ii <= nxa; ++ii) {
-                        ddx = xyout[0] - (double)ii;
+                        ddx = ox - (double)ii;
 
                         /* Radial distance */
                         r2 = ddx*ddx + ddy*ddy;
@@ -507,17 +507,17 @@ do_kernel_gaussian(struct driz_param_t* p) {
         }
 
         for (i = xmin; i <= xmax; ++i) {
-            double xyout[2];
+            double ox, oy;
 
-            if (map_pixel(p->pixmap, i, j, xyout)) {
+            if (map_pixel(p->pixmap, i, j, &ox, &oy)) {
                 nhit = 0;
 
             } else {
                 /* Offset within the subset */
-                xxi = xyout[0] - pfo;
-                xxa = xyout[0] + pfo;
-                yyi = xyout[1] - pfo;
-                yya = xyout[1] + pfo;
+                xxi = ox - pfo;
+                xxa = ox + pfo;
+                yyi = oy - pfo;
+                yya = oy + pfo;
 
                 nxi = MAX(fortran_round(xxi), 0);
                 nxa = MIN(fortran_round(xxa), osize[0]-1);
@@ -539,9 +539,9 @@ do_kernel_gaussian(struct driz_param_t* p) {
 
                 /* Loop over output pixels which could be affected */
                 for (jj = nyi; jj <= nya; ++jj) {
-                    ddy = xyout[1]- (double)jj;
+                    ddy = oy - (double)jj;
                     for (ii = nxi; ii <= nxa; ++ii) {
-                        ddx = xyout[0] - (double)ii;
+                        ddx = ox - (double)ii;
                         /* Radial distance */
                         r2 = ddx*ddx + ddy*ddy;
 
@@ -642,15 +642,10 @@ do_kernel_lanczos(struct driz_param_t* p) {
         }
 
         for (i = xmin; i <= xmax; ++i) {
-            double xyout[2];
-
-            if (map_pixel(p->pixmap, i, j, xyout)) {
+            if (map_pixel(p->pixmap, i, j, &xx, &yy)) {
                 nhit = 0;
 
             } else {
-                xx = xyout[0];
-                yy = xyout[1];
-
                 xxi = xx - dx - pfo;
                 xxa = xx - dx + pfo;
                 yyi = yy - dy - pfo;
@@ -766,17 +761,17 @@ do_kernel_turbo(struct driz_param_t* p) {
         }
 
         for (i = xmin; i <= xmax; ++i) {
-            double xyout[2];
+            double ox, oy;
 
-            if (map_pixel(p->pixmap, i, j, xyout)) {
+            if (map_pixel(p->pixmap, i, j, &ox, &oy)) {
                 nhit = 0;
 
             } else {
                 /* Offset within the subset */
-                xxi = xyout[0] - pfo;
-                xxa = xyout[0] + pfo;
-                yyi = xyout[1] - pfo;
-                yya = xyout[1] + pfo;
+                xxi = ox - pfo;
+                xxa = ox + pfo;
+                yyi = oy - pfo;
+                yya = oy + pfo;
 
                 nxi = fortran_round(xxi);
                 nxa = fortran_round(xxa);

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -313,7 +313,7 @@ do_kernel_point(struct driz_param_t* p) {
                         dow = 1.0;
                     }
 
-                    /* If we are creating of modifying the context image,
+                    /* If we are creating or modifying the context image,
                        we do so here. */
                     if (p->output_context && dow > 0.0) {
                         set_bit(p->output_context, ii, jj, bv);
@@ -951,8 +951,8 @@ do_kernel_square(struct driz_param_t* p) {
                         /* Count the hits */
                         ++nhit;
 
-                        /* If we are creating or modifying the context image we do
-                           so here */
+                        /* If we are creating or modifying the context image we
+                           do so here */
                         if (p->output_context && dow > 0.0) {
                             set_bit(p->output_context, ii, jj, bv);
                         }

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -27,11 +27,11 @@ update_data(struct driz_param_t* p, const integer_t ii, const integer_t jj,
             const float d, const float vc, const float dow) {
 
   double vc_plus_dow;
-  
+
   if (dow == 0.0f) return 0;
-  
+
   vc_plus_dow = vc + dow;
-  
+
   if (vc == 0.0f) {
     if (oob_pixel(p->output_data, ii, jj)) {
       driz_error_format_message(p->error, "OOB in output_data[%d,%d]", ii, jj);
@@ -71,7 +71,7 @@ integer_t
 compute_bit_value(integer_t uuid) {
   integer_t bv;
   int np, bit_no;
-  
+
   np = (uuid - 1) / 32 + 1;
   bit_no = (uuid - 1 - (32 * (np - 1)));
   bv = (integer_t)(1 << bit_no);
@@ -96,10 +96,10 @@ compute_area(double is, double js, const double x[4], const double y[4]) {
   double area, width;
   double midpoint[2], delta[2];
   double border[2][2], segment[2][2];
-  
+
   /* The area for a qadrilateral clipped to a square of unit length whose sides are
    * aligned with the axes. The area is computed by computing the area under each
-   * line segment clipped to the boundary of three sides of the sqaure. Since the 
+   * line segment clipped to the boundary of three sides of the sqaure. Since the
    * computed width is positive for two of the sides and negative for the other two,
    * we subtract the area outside the quadrilateral without any extra code.
    */
@@ -109,7 +109,7 @@ compute_area(double is, double js, const double x[4], const double y[4]) {
   border[0][1] = js - 0.5;
   border[1][0] = is + 0.5;
   border[1][1] = js + 0.5;
-  
+
   for (ipoint = 0; ipoint < 4; ++ ipoint) {
     jpoint = (ipoint + 1) & 03; /* Next point in cyclical order */
 
@@ -117,14 +117,14 @@ compute_area(double is, double js, const double x[4], const double y[4]) {
     segment[0][1] = y[ipoint];
     segment[1][0] = x[jpoint];
     segment[1][1] = y[jpoint];
-  
-    /* Compute the endpoints of the line segment that 
-     * lie inside the border (possibly the whole segment) 
+
+    /* Compute the endpoints of the line segment that
+     * lie inside the border (possibly the whole segment)
      */
-    
+
     for (idim = 0, count = 3; idim < 2; ++ idim) {
       for (iside = 0; iside < 2; ++ iside, -- count) {
-	
+
         delta[0] = segment[0][idim] - border[iside][idim];
         delta[1] = segment[1][idim] - border[iside][idim];
 
@@ -146,12 +146,12 @@ compute_area(double is, double js, const double x[4], const double y[4]) {
             } else {
               goto _nextsegment;
             }
-	    
+
           } else {
             /* Segment entirely within the boundary */
             if (count == 0) {
-              /* Use the trapezoid formula to compute the area under the 
-               * segment. Delta is the distance to the top of the square 
+              /* Use the trapezoid formula to compute the area under the
+               * segment. Delta is the distance to the top of the square
                * and is negative or zero for the segment inside the square
                */
               width = segment[1][0] - segment[0][0];
@@ -167,7 +167,7 @@ compute_area(double is, double js, const double x[4], const double y[4]) {
           jdim = (idim + 1) & 01; /* the other dimension */
 
           midpoint[idim] = border[iside][idim];
-	  
+
           midpoint[jdim] =
             (delta[1] * segment[0][jdim] - delta[0] * segment[1][jdim]) /
             (delta[1] - delta[0]);
@@ -238,54 +238,65 @@ over(const integer_t i, const integer_t j,
 }
 
 /** --------------------------------------------------------------------------------------------------
- * The kernel assumes all the flux in an input pixel is at the center 
+ * The kernel assumes all the flux in an input pixel is at the center
  *
  * p: structure containing options, input, and output
  */
 
 static int
 do_kernel_point(struct driz_param_t* p) {
+  struct scanner s;
   integer_t i, j, ii, jj;
-  integer_t xbounds[2], ybounds[2], osize[2];
+  integer_t ybounds[2], osize[2];
   float scale2, vc, d, dow;
   integer_t bv;
-  int margin;
+  int xmin, xmax, ymin, ymax, n;
 
   scale2 = p->scale * p->scale;
   bv = compute_bit_value(p->uuid);
-  
-  margin = 2;
-  if (check_image_overlap(p, margin, ybounds)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ybounds[1] - ybounds[0]);
+  if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
+
+  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
 
   /* This is the outer loop over all the lines in the input image */
-  
-  get_dimensions(p->output_data, osize);
-  for (j = ybounds[0]; j < ybounds[1]; ++j) {
-    /* Check the overlap with the output */
-    if (check_line_overlap(p, margin, j, xbounds)) return 1;
-    
-    /* We know there may be some misses */
-    p->nmiss += (p->xmax - p->xmin) - (xbounds[1] - xbounds[0]);
-    if (xbounds[0] == xbounds[1]) ++ p->nskip;
 
-    for (i = xbounds[0]; i < xbounds[1]; ++i) {
+  get_dimensions(p->output_data, osize);
+  for (j = ymin; j <= ymax; ++j) {
+    /* Check the overlap with the output */
+    n = get_scanline_limits(&s, j, &xmin, &xmax);
+    if (n == 1) {
+        // scan ended (y reached the top vertex/edge)
+        p->nskip += (ymax + 1 - j);
+        p->nmiss += (ymax + 1 - j) * (p->xmax - p->xmin);
+        break;
+    } else if (n == 2 || n == 3) {
+        // pixel centered on y is outside of scanner's limits or image [0, height - 1]
+        // OR: limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin);
+        ++p->nskip;
+        continue;
+    } else {
+        // limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin) - (xmax + 1 - xmin);
+    }
+
+    for (i = xmin; i <= xmax; ++i) {
       double xyout[2];
 
       if (map_pixel(p->pixmap, i, j, xyout)) {
         ++ p->nmiss;
-        
+
       } else {
         ii = fortran_round(xyout[0]);
         jj = fortran_round(xyout[1]);
-        
+
         /* Check it is on the output image */
         if (ii < 0 || ii >= osize[0] || jj < 0 || jj >= osize[1]) {
           ++ p->nmiss;
 
-        } else {  
+        } else {
           if (oob_pixel(p->output_counts, ii, jj)) {
             driz_error_format_message(p->error, "OOB in output_counts[%d,%d]", ii, jj);
             return 1;
@@ -300,7 +311,7 @@ do_kernel_point(struct driz_param_t* p) {
           } else {
             d = get_pixel(p->data, i, j) * scale2;
           }
-        
+
           /* Scale the weighting mask by the scale factor.  Note that we
              DON'T scale by the Jacobian as it hasn't been calculated */
           if (p->weights) {
@@ -310,17 +321,17 @@ do_kernel_point(struct driz_param_t* p) {
             } else {
               dow = get_pixel(p->weights, i, j) * p->weight_scale;
             }
-    
+
           } else {
             dow = 1.0;
           }
-  
+
           /* If we are creating of modifying the context image,
              we do so here. */
           if (p->output_context && dow > 0.0) {
             set_bit(p->output_context, ii, jj, bv);
           }
-  
+
           if (update_data(p, ii, jj, d, vc, dow)) {
             return 1;
           }
@@ -328,49 +339,60 @@ do_kernel_point(struct driz_param_t* p) {
       }
     }
   }
-  
+
   return 0;
 }
 
 /** --------------------------------------------------------------------------------------------------
  * This kernel assumes flux is distrubuted evenly across a circle around the center of a pixel
- * 
+ *
  * p: structure containing options, input, and output
  */
 
 static int
 do_kernel_tophat(struct driz_param_t* p) {
+  struct scanner s;
   integer_t bv, i, j, ii, jj, nhit, nxi, nxa, nyi, nya;
-  integer_t xbounds[2], ybounds[2], osize[2];
+  integer_t ybounds[2], osize[2];
   float scale2, pfo, pfo2, vc, d, dow;
   double xxi, xxa, yyi, yya, ddx, ddy, r2;
-  int margin;
-  
+  int xmin, xmax, ymin, ymax, n;
+
   scale2 = p->scale * p->scale;
   pfo = p->pixel_fraction / p->scale / 2.0;
   pfo2 = pfo * pfo;
   bv = compute_bit_value(p->uuid);
- 
-  margin = 2;
-  if (check_image_overlap(p, margin, ybounds)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ybounds[1] - ybounds[0]);
+  if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
+
+  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
-  
+
   /* This is the outer loop over all the lines in the input image */
 
   get_dimensions(p->output_data, osize);
-  for (j = ybounds[0]; j < ybounds[1]; ++j) {
+  for (j = ymin; j <= ymax; ++j) {
     /* Check the overlap with the output */
-    if (check_line_overlap(p, margin, j, xbounds)) return 1;
-    
-    /* We know there may be some misses */
-    p->nmiss += (p->xmax - p->xmin) - (xbounds[1] - xbounds[0]);
-    if (xbounds[0] == xbounds[1]) ++ p->nskip;
+    n = get_scanline_limits(&s, j, &xmin, &xmax);
+    if (n == 1) {
+        // scan ended (y reached the top vertex/edge)
+        p->nskip += (ymax + 1 - j);
+        p->nmiss += (ymax + 1 - j) * (p->xmax - p->xmin);
+        break;
+    } else if (n == 2 || n == 3) {
+        // pixel centered on y is outside of scanner's limits or image [0, height - 1]
+        // OR: limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin);
+        ++p->nskip;
+        continue;
+    } else {
+        // limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin) - (xmax + 1 - xmin);
+    }
 
-    for (i = xbounds[0]; i < xbounds[1]; ++i) {
+    for (i = xmin; i <= xmax; ++i) {
       double xyout[2];
-      
+
       if (map_pixel(p->pixmap, i, j, xyout)) {
         nhit = 0;
 
@@ -380,14 +402,14 @@ do_kernel_tophat(struct driz_param_t* p) {
         xxa = xyout[0] + pfo;
         yyi = xyout[1] - pfo;
         yya = xyout[1] + pfo;
-  
+
         nxi = MAX(fortran_round(xxi), 0);
         nxa = MIN(fortran_round(xxa), osize[0]-1);
         nyi = MAX(fortran_round(yyi), 0);
         nya = MIN(fortran_round(yya), osize[1]-1);
-  
+
         nhit = 0;
-  
+
         /* Allow for stretching because of scale change */
         if (oob_pixel(p->data, i, j)) {
           driz_error_format_message(p->error, "OOB in data[%d,%d]", i, j);
@@ -405,22 +427,22 @@ do_kernel_tophat(struct driz_param_t* p) {
           } else {
             dow = get_pixel(p->weights, i, j) * p->weight_scale;
           }
-        
+
         } else {
           dow = 1.0;
         }
-  
+
         /* Loop over output pixels which could be affected */
         for (jj = nyi; jj <= nya; ++jj) {
           ddy = xyout[1]- (double)jj;
-  
+
           /* Check it is on the output image */
           for (ii = nxi; ii <= nxa; ++ii) {
             ddx = xyout[0] - (double)ii;
-  
+
             /* Radial distance */
             r2 = ddx*ddx + ddy*ddy;
-  
+
             /* Weight is one within the specified radius and zero outside.
                Note: weight isn't conserved in this case */
             if (r2 <= pfo2) {
@@ -432,13 +454,13 @@ do_kernel_tophat(struct driz_param_t* p) {
               } else {
                 vc = get_pixel(p->output_counts, ii, jj);
               }
-  
+
               /* If we are create or modifying the context image,
                  we do so here. */
               if (p->output_context && dow > 0.0) {
                 set_bit(p->output_context, ii, jj, bv);
               }
-  
+
               if (update_data(p, ii, jj, d, vc, dow)) {
                 return 1;
               }
@@ -446,7 +468,7 @@ do_kernel_tophat(struct driz_param_t* p) {
           }
         }
       }
-  
+
       /* Count cases where the pixel is off the output image */
       if (nhit == 0) ++ p->nmiss;
     }
@@ -457,54 +479,65 @@ do_kernel_tophat(struct driz_param_t* p) {
 
 /** --------------------------------------------------------------------------------------------------
  * This kernel assumes the flux is distributed acrass a gaussian around the center of an input pixel
- * 
+ *
  * p: structure containing options, input, and output
  */
 
 static int
 do_kernel_gaussian(struct driz_param_t* p) {
+  struct scanner s;
   integer_t bv, i, j, ii, jj, nxi, nxa, nyi, nya, nhit;
-  integer_t xbounds[2], ybounds[2], osize[2];
+  integer_t ybounds[2], osize[2];
   float vc, d, dow;
   double gaussian_efac, gaussian_es;
   double pfo, ac,  scale2, xxi, xxa, yyi, yya, w, ddx, ddy, r2, dover;
   const double nsig = 2.5;
-  int margin;
-  
+  int xmin, xmax, ymin, ymax, n;
+
   /* Added in V2.9 - make sure pfo doesn't get less than 1.2
      divided by the scale so that there are never holes in the
      output */
 
   pfo = nsig * p->pixel_fraction / 2.3548 / p->scale;
   pfo = CLAMP_ABOVE(pfo, 1.2 / p->scale);
-  
+
   ac = 1.0 / (p->pixel_fraction * p->pixel_fraction);
   scale2 = p->scale * p->scale;
   bv = compute_bit_value(p->uuid);
-  
+
   gaussian_efac = (2.3548*2.3548) * scale2 * ac / 2.0;
   gaussian_es = gaussian_efac / M_PI;
 
-  margin = 2;
-  if (check_image_overlap(p, margin, ybounds)) return 1;
+  if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ybounds[1] - ybounds[0]);
+  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
- 
+
   /* This is the outer loop over all the lines in the input image */
 
   get_dimensions(p->output_data, osize);
-  for (j = ybounds[0]; j < ybounds[1]; ++j) {
+  for (j = ymin; j <= ymax; ++j) {
     /* Check the overlap with the output */
-    if (check_line_overlap(p, margin, j, xbounds)) return 1;
-    
-    /* We know there may be some misses */
-    p->nmiss += (p->xmax - p->xmin) - (xbounds[1] - xbounds[0]);
-    if (xbounds[0] == xbounds[1]) ++ p->nskip;
+    n = get_scanline_limits(&s, j, &xmin, &xmax);
+    if (n == 1) {
+        // scan ended (y reached the top vertex/edge)
+        p->nskip += (ymax + 1 - j);
+        p->nmiss += (ymax + 1 - j) * (p->xmax - p->xmin);
+        break;
+    } else if (n == 2 || n == 3) {
+        // pixel centered on y is outside of scanner's limits or image [0, height - 1]
+        // OR: limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin);
+        ++p->nskip;
+        continue;
+    } else {
+        // limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin) - (xmax + 1 - xmin);
+    }
 
-    for (i = xbounds[0]; i < xbounds[1]; ++i) {
+    for (i = xmin; i <= xmax; ++i) {
       double xyout[2];
-      
+
       if (map_pixel(p->pixmap, i, j, xyout)) {
         nhit = 0;
 
@@ -514,14 +547,14 @@ do_kernel_gaussian(struct driz_param_t* p) {
         xxa = xyout[0] + pfo;
         yyi = xyout[1] - pfo;
         yya = xyout[1] + pfo;
-  
+
         nxi = MAX(fortran_round(xxi), 0);
         nxa = MIN(fortran_round(xxa), osize[0]-1);
         nyi = MAX(fortran_round(yyi), 0);
         nya = MIN(fortran_round(yya), osize[1]-1);
-  
+
         nhit = 0;
-  
+
         /* Allow for stretching because of scale change */
         if (oob_pixel(p->data, i, j)) {
           driz_error_format_message(p->error, "OOB in data[%d,%d]", i, j);
@@ -543,7 +576,7 @@ do_kernel_gaussian(struct driz_param_t* p) {
         } else {
           w = 1.0;
         }
-  
+
         /* Loop over output pixels which could be affected */
         for (jj = nyi; jj <= nya; ++jj) {
           ddy = xyout[1]- (double)jj;
@@ -551,14 +584,14 @@ do_kernel_gaussian(struct driz_param_t* p) {
             ddx = xyout[0] - (double)ii;
             /* Radial distance */
             r2 = ddx*ddx + ddy*ddy;
-  
+
             /* Weight is a scaled Gaussian function of radial
                distance */
             dover = gaussian_es * exp(-r2 * gaussian_efac);
-  
+
             /* Count the hits */
             ++nhit;
-  
+
             if (oob_pixel(p->output_counts, ii, jj)) {
               driz_error_format_message(p->error, "OOB in output_counts[%d,%d]", ii, jj);
               return 1;
@@ -567,13 +600,13 @@ do_kernel_gaussian(struct driz_param_t* p) {
             }
 
             dow = (float)dover * w;
-  
+
             /* If we are create or modifying the context image, we do so
                here. */
             if (p->output_context && dow > 0.0) {
               set_bit(p->output_context, ii, jj, bv);
             }
-  
+
             if (update_data(p, ii, jj, d, vc, dow)) {
               return 1;
             }
@@ -591,21 +624,22 @@ do_kernel_gaussian(struct driz_param_t* p) {
 
 /** --------------------------------------------------------------------------------------------------
  * This kernel assumes flux of input pixel is distributed according to lanczos function
- * 
+ *
  * p: structure containing options, input, and output
  */
 
 static int
 do_kernel_lanczos(struct driz_param_t* p) {
+  struct scanner s;
   integer_t bv, i, j, ii, jj, nxi, nxa, nyi, nya, nhit, ix, iy;
-  integer_t xbounds[2], ybounds[2], osize[2];
+  integer_t ybounds[2], osize[2];
   float scale2, vc, d, dow;
   double pfo, xx, yy, xxi, xxa, yyi, yya, w, dx, dy, dover;
   int kernel_order;
-  int margin;
   struct lanczos_param_t lanczos;
   const size_t nlut = 512;
   const float del = 0.01;
+  int xmin, xmax, ymin, ymax, n;
 
   dx = 1.0;
   dy = 1.0;
@@ -614,38 +648,48 @@ do_kernel_lanczos(struct driz_param_t* p) {
   kernel_order = (p->kernel == kernel_lanczos2) ? 2 : 3;
   pfo = (double)kernel_order * p->pixel_fraction / p->scale;
   bv = compute_bit_value(p->uuid);
-  
+
   if ((lanczos.lut = malloc(nlut * sizeof(float))) == NULL) {
     driz_error_set_message(p->error, "Out of memory");
     return driz_error_is_set(p->error);
   }
-  
+
   /* Set up a look-up-table for Lanczos-style interpolation
      kernels */
   create_lanczos_lut(kernel_order, nlut, del, lanczos.lut);
   lanczos.sdp = p->scale / del / p->pixel_fraction;
   lanczos.nlut = nlut;
 
-  margin = 2;
-  if (check_image_overlap(p, margin, ybounds)) return 1;
+  if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ybounds[1] - ybounds[0]);
+  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
-  
+
   /* This is the outer loop over all the lines in the input image */
 
   get_dimensions(p->output_data, osize);
-  for (j = ybounds[0]; j < ybounds[1]; ++j) {
+  for (j = ymin; j <= ymax; ++j) {
     /* Check the overlap with the output */
-    if (check_line_overlap(p, margin, j, xbounds)) return 1;
-    
-    /* We know there may be some misses */
-    p->nmiss += (p->xmax - p->xmin) - (xbounds[1] - xbounds[0]);
-    if (xbounds[0] == xbounds[1]) ++ p->nskip;
+    n = get_scanline_limits(&s, j, &xmin, &xmax);
+    if (n == 1) {
+        // scan ended (y reached the top vertex/edge)
+        p->nskip += (ymax + 1 - j);
+        p->nmiss += (ymax + 1 - j) * (p->xmax - p->xmin);
+        break;
+    } else if (n == 2 || n == 3) {
+        // pixel centered on y is outside of scanner's limits or image [0, height - 1]
+        // OR: limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin);
+        ++p->nskip;
+        continue;
+    } else {
+        // limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin) - (xmax + 1 - xmin);
+    }
 
-    for (i = xbounds[0]; i < xbounds[1]; ++i) {
+    for (i = xmin; i <= xmax; ++i) {
       double xyout[2];
-      
+
       if (map_pixel(p->pixmap, i, j, xyout)) {
         nhit = 0;
 
@@ -657,14 +701,14 @@ do_kernel_lanczos(struct driz_param_t* p) {
         xxa = xx - dx + pfo;
         yyi = yy - dy - pfo;
         yya = yy - dy + pfo;
-  
+
         nxi = MAX(fortran_round(xxi), 0);
         nxa = MIN(fortran_round(xxa), osize[0]-1);
         nyi = MAX(fortran_round(yyi), 0);
         nya = MIN(fortran_round(yya), osize[1]-1);
-  
+
         nhit = 0;
-  
+
         /* Allow for stretching because of scale change */
         if (oob_pixel(p->data, i, j)) {
           driz_error_format_message(p->error, "OOB in data[%d,%d]", i, j);
@@ -686,20 +730,20 @@ do_kernel_lanczos(struct driz_param_t* p) {
         } else {
           w = 1.0;
         }
-  
+
         /* Loop over output pixels which could be affected */
         for (jj = nyi; jj <= nya; ++jj) {
           for (ii = nxi; ii <= nxa; ++ii) {
             /* X and Y offsets */
             ix = fortran_round(fabs(xx - (double)ii) * lanczos.sdp) + 1;
             iy = fortran_round(fabs(yy - (double)jj) * lanczos.sdp) + 1;
-  
+
             /* Weight is product of Lanczos function values in X and Y */
             dover = lanczos.lut[ix] * lanczos.lut[iy];
-  
+
             /* Count the hits */
             ++nhit;
-  
+
             if (oob_pixel(p->output_counts, ii, jj)) {
               driz_error_format_message(p->error, "OOB in output_counts[%d,%d]", ii, jj);
               return 1;
@@ -707,71 +751,82 @@ do_kernel_lanczos(struct driz_param_t* p) {
               vc = get_pixel(p->output_counts, ii, jj);
             }
             dow = (float)(dover * w);
-  
+
             /* If we are create or modifying the context image, we do so
                here. */
             if (p->output_context && dow > 0.0) {
               set_bit(p->output_context, ii, jj, bv);
             }
-  
+
             if (update_data(p, ii, jj, d, vc, dow)) {
               return 1;
             }
           }
         }
       }
-  
+
       /* Count cases where the pixel is off the output image */
       if (nhit == 0) ++ p->nmiss;
     }
   }
-  
+
   free(lanczos.lut);
   lanczos.lut = NULL;
-  
+
   return 0;
 }
 
 /** --------------------------------------------------------------------------------------------------
  * This kernel assumes the input flux is evenly distributed over a rectangle whose sides are
  * aligned with the ouput pixel. Called turbo because it is fast, but approximate.
- * 
+ *
  * p: structure containing options, input, and output
  */
 
 static int
 do_kernel_turbo(struct driz_param_t* p) {
+  struct scanner s;
   integer_t bv, i, j, ii, jj, nxi, nxa, nyi, nya, nhit, iis, iie, jjs, jje;
-  integer_t xbounds[2], ybounds[2], osize[2];
+  integer_t osize[2];
   float vc, d, dow;
   double pfo, scale2, ac;
   double xxi, xxa, yyi, yya, w, dover;
-  int margin;
-    
-  driz_log_message("starting do_kernel_turbo");  
+  int xmin, xmax, ymin, ymax, n;
+
+  driz_log_message("starting do_kernel_turbo");
   bv = compute_bit_value(p->uuid);
   ac = 1.0 / (p->pixel_fraction * p->pixel_fraction);
   pfo = p->pixel_fraction / p->scale / 2.0;
   scale2 = p->scale * p->scale;
-  
-  margin = 2;
-  if (check_image_overlap(p, margin, ybounds)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ybounds[1] - ybounds[0]);
+  if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
+
+  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
-  
-  /* This is the outer loop over all the lines in the input image */
-  
-  get_dimensions(p->output_data, osize);
-  for (j = ybounds[0]; j < ybounds[1]; ++j) {
-    /* Check the overlap with the output */
-    if (check_line_overlap(p, margin, j, xbounds)) return 1;
-    
-    /* We know there may be some misses */
-    p->nmiss += (p->xmax - p->xmin) - (xbounds[1] - xbounds[0]);
-    if (xbounds[0] == xbounds[1]) ++ p->nskip;
 
-    for (i = xbounds[0]; i < xbounds[1]; ++i) {
+  /* This is the outer loop over all the lines in the input image */
+
+  get_dimensions(p->output_data, osize);
+  for (j = ymin; j <= ymax; ++j) {
+    /* Check the overlap with the output */
+    n = get_scanline_limits(&s, j, &xmin, &xmax);
+    if (n == 1) {
+        // scan ended (y reached the top vertex/edge)
+        p->nskip += (ymax + 1 - j);
+        p->nmiss += (ymax + 1 - j) * (p->xmax - p->xmin);
+        break;
+    } else if (n == 2 || n == 3) {
+        // pixel centered on y is outside of scanner's limits or image [0, height - 1]
+        // OR: limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin);
+        ++p->nskip;
+        continue;
+    } else {
+        // limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin) - (xmax + 1 - xmin);
+    }
+
+    for (i = xmin; i <= xmax; ++i) {
       double xyout[2];
 
       if (map_pixel(p->pixmap, i, j, xyout)) {
@@ -792,9 +847,9 @@ do_kernel_turbo(struct driz_param_t* p) {
         iie = MIN(nxa, osize[0]-1);
         jjs = MAX(nyi, 0);  /* Needed to be set to 0 to avoid edge effects */
         jje = MIN(nya, osize[1]-1);
-  
+
         nhit = 0;
-  
+
         /* Allow for stretching because of scale change */
         if (oob_pixel(p->data, i, j)) {
           driz_error_format_message(p->error, "OOB in data[%d,%d]", i, j);
@@ -822,15 +877,15 @@ do_kernel_turbo(struct driz_param_t* p) {
           for (ii = iis; ii <= iie; ++ii) {
             /* Calculate the overlap using the simpler "aligned" box
                routine */
-            dover = over(ii, jj, xxi, xxa, yyi, yya);   
-          
+            dover = over(ii, jj, xxi, xxa, yyi, yya);
+
             if (dover > 0.0) {
               /* Correct for the pixfrac area factor */
               dover *= scale2 * ac;
-  
+
               /* Count the hits */
               ++nhit;
-  
+
               if (oob_pixel(p->output_counts, ii, jj)) {
                 driz_error_format_message(p->error, "OOB in output_counts[%d,%d]", ii, jj);
                 return 1;
@@ -838,13 +893,13 @@ do_kernel_turbo(struct driz_param_t* p) {
                 vc = get_pixel(p->output_counts, ii, jj);
               }
               dow = (float)(dover * w);
-  
+
               /* If we are create or modifying the context image,
                  we do so here. */
               if (p->output_context && dow > 0.0) {
                 set_bit(p->output_context, ii, jj, bv);
               }
-  
+
               if (update_data(p, ii, jj, d, vc, dow)) {
                 return 1;
               }
@@ -852,7 +907,7 @@ do_kernel_turbo(struct driz_param_t* p) {
           }
         }
       }
-  
+
       /* Count cases where the pixel is off the output image */
       if (nhit == 0) ++ p->nmiss;
     }
@@ -873,54 +928,63 @@ do_kernel_turbo(struct driz_param_t* p) {
 int
 do_kernel_square(struct driz_param_t* p) {
   integer_t bv, i, j, ii, jj, min_ii, max_ii, min_jj, max_jj, nhit;
-  integer_t xbounds[2], ybounds[2], osize[2];
+  integer_t osize[2];
   float scale2, vc, d, dow;
   double dh, jaco, tem, dover, w;
   double xyin[4][2], xyout[2], xout[4], yout[4];
-  int margin;
-  
-  driz_log_message("starting do_kernel_square");  
+  struct scanner s;
+  int xmin, xmax, ymin, ymax, n;
+
+  driz_log_message("starting do_kernel_square");
   dh = 0.5 * p->pixel_fraction;
   bv = compute_bit_value(p->uuid);
   scale2 = p->scale * p->scale;
-  
+
   /* Next the "classic" drizzle square kernel...  this is different
      because we have to transform all four corners of the shrunken
      pixel */
+  if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
 
-  margin = 2;
-  if (check_image_overlap(p, margin, ybounds)) return 1;
-
-  p->nskip = (p->ymax - p->ymin) - (ybounds[1] - ybounds[0]);
+  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
-  
+
   /* This is the outer loop over all the lines in the input image */
 
-  get_dimensions(p->output_data, osize);  
-  for (j = ybounds[0]; j < ybounds[1]; ++j) {
+  get_dimensions(p->output_data, osize);
+  for (j = ymin; j <= ymax; ++j) {
     /* Check the overlap with the output */
-    if (check_line_overlap(p, margin, j, xbounds)) return 1;
-    
-    /* We know there may be some misses */
-
-    p->nmiss += (p->xmax - p->xmin) - (xbounds[1] - xbounds[0]);
-    if (xbounds[0] == xbounds[1]) ++ p->nskip;
+    n = get_scanline_limits(&s, j, &xmin, &xmax);
+    if (n == 1) {
+        // scan ended (y reached the top vertex/edge)
+        p->nskip += (ymax + 1 - j);
+        p->nmiss += (ymax + 1 - j) * (p->xmax - p->xmin);
+        break;
+    } else if (n == 2 || n == 3) {
+        // pixel centered on y is outside of scanner's limits or image [0, height - 1]
+        // OR: limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin);
+        ++p->nskip;
+        continue;
+    } else {
+        // limits (x1, x2) are equal (line width is 0)
+        p->nmiss += (p->xmax - p->xmin) - (xmax + 1 - xmin);
+    }
 
     /* Set the input corner positions */
-  
+
     xyin[0][1] = (double) j + dh;
     xyin[1][1] = (double) j + dh;
     xyin[2][1] = (double) j - dh;
     xyin[3][1] = (double) j - dh;
-  
-    for (i = xbounds[0]; i < xbounds[1]; ++i) {
+
+    for (i = xmin; i <= xmax; ++i) {
       nhit = 0;
 
       xyin[0][0] = (double) i - dh;
       xyin[1][0] = (double) i + dh;
       xyin[2][0] = (double) i + dh;
       xyin[3][0] = (double) i - dh;
-  
+
       for (ii = 0; ii < 4; ++ii) {
         if (map_point(p->pixmap, xyin[ii], xyout)) {
             goto _miss;
@@ -928,21 +992,21 @@ do_kernel_square(struct driz_param_t* p) {
         xout[ii] = xyout[0];
         yout[ii] = xyout[1];
       }
-  
+
       /* Work out the area of the quadrilateral on the output grid.
          Note that this expression expects the points to be in clockwise
          order */
-      
+
       jaco = 0.5f * ((xout[1] - xout[3]) * (yout[0] - yout[2]) -
                      (xout[0] - xout[2]) * (yout[1] - yout[3]));
-  
+
       if (jaco < 0.0) {
         jaco *= -1.0;
         /* Swap */
         tem = xout[1]; xout[1] = xout[3]; xout[3] = tem;
         tem = yout[1]; yout[1] = yout[3]; yout[3] = tem;
       }
-    
+
       /* Allow for stretching because of scale change */
       if (oob_pixel(p->data, i, j)) {
         driz_error_format_message(p->error, "OOB in data[%d,%d]", i, j);
@@ -950,7 +1014,7 @@ do_kernel_square(struct driz_param_t* p) {
       } else {
         d = get_pixel(p->data, i, j) * scale2;
       }
-      
+
       /* Scale the weighting mask by the scale factor and inversely by
          the Jacobian to ensure conservation of weight in the output */
       if (p->weights) {
@@ -963,13 +1027,13 @@ do_kernel_square(struct driz_param_t* p) {
       } else {
         w = 1.0;
       }
-  
+
       /* Loop over output pixels which could be affected */
       min_jj = MAX(fortran_round(min_doubles(yout, 4)), 0);
       max_jj = MIN(fortran_round(max_doubles(yout, 4)), osize[1]-1);
       min_ii = MAX(fortran_round(min_doubles(xout, 4)), 0);
       max_ii = MIN(fortran_round(max_doubles(xout, 4)), osize[0]-1);
-  
+
       for (jj = min_jj; jj <= max_jj; ++jj) {
         for (ii = min_ii; ii <= max_ii; ++ii) {
           /* Call compute_area to calculate overlap */
@@ -982,14 +1046,14 @@ do_kernel_square(struct driz_param_t* p) {
             } else {
               vc = get_pixel(p->output_counts, ii, jj);
             }
-  
+
             /* Re-normalise the area overlap using the Jacobian */
             dover /= jaco;
             dow = (float)(dover * w);
 
             /* Count the hits */
-            ++nhit;  
-  
+            ++nhit;
+
             /* If we are creating or modifying the context image we do
                so here */
             if (p->output_context && dow > 0.0) {
@@ -1000,14 +1064,14 @@ do_kernel_square(struct driz_param_t* p) {
                 set_bit(p->output_context, ii, jj, bv);
               }
             }
-  
+
             if (update_data(p, ii, jj, d, vc, dow)) {
               return 1;
             }
           }
         }
       }
-  
+
       /* Count cases where the pixel is off the output image */
       _miss:
       if (nhit == 0) {
@@ -1039,7 +1103,7 @@ kernel_handler_map[] = {
 
 /** --------------------------------------------------------------------------------------------------
  * The executive function which calls the kernel which does the actual drizzling
- * 
+ *
  * p: structure containing options, input, and output
  */
 
@@ -1047,11 +1111,11 @@ int
 dobox(struct driz_param_t* p) {
   kernel_handler_t kernel_handler = NULL;
   driz_log_message("starting dobox");
-  
+
   /* Set up a function pointer to handle the appropriate kernel */
   if (p->kernel < kernel_LAST) {
     kernel_handler = kernel_handler_map[p->kernel];
-    
+
     if (kernel_handler != NULL) {
       kernel_handler(p);
     }
@@ -1060,7 +1124,7 @@ dobox(struct driz_param_t* p) {
   if (kernel_handler == NULL) {
     driz_error_set_message(p->error, "Invalid kernel type");
   }
- 
+
   driz_log_message("ending dobox");
   return driz_error_is_set(p->error);
 }

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -257,7 +257,7 @@ do_kernel_point(struct driz_param_t* p) {
 
   if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
+  p->nskip = (p->ymax - p->ymin) - (ymax - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
 
   /* This is the outer loop over all the lines in the input image */
@@ -365,7 +365,7 @@ do_kernel_tophat(struct driz_param_t* p) {
 
   if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
+  p->nskip = (p->ymax - p->ymin) - (ymax - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
 
   /* This is the outer loop over all the lines in the input image */
@@ -510,7 +510,7 @@ do_kernel_gaussian(struct driz_param_t* p) {
 
   if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
+  p->nskip = (p->ymax - p->ymin) - (ymax - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
 
   /* This is the outer loop over all the lines in the input image */
@@ -662,7 +662,7 @@ do_kernel_lanczos(struct driz_param_t* p) {
 
   if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
+  p->nskip = (p->ymax - p->ymin) - (ymax - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
 
   /* This is the outer loop over all the lines in the input image */
@@ -801,7 +801,7 @@ do_kernel_turbo(struct driz_param_t* p) {
 
   if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
+  p->nskip = (p->ymax - p->ymin) - (ymax - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
 
   /* This is the outer loop over all the lines in the input image */
@@ -810,6 +810,7 @@ do_kernel_turbo(struct driz_param_t* p) {
   for (j = ymin; j <= ymax; ++j) {
     /* Check the overlap with the output */
     n = get_scanline_limits(&s, j, &xmin, &xmax);
+
     if (n == 1) {
         // scan ended (y reached the top vertex/edge)
         p->nskip += (ymax + 1 - j);
@@ -945,7 +946,7 @@ do_kernel_square(struct driz_param_t* p) {
      pixel */
   if (init_image_scanner(p, &s, &ymin, &ymax)) return 1;
 
-  p->nskip = (p->ymax - p->ymin) - (ymax + 1 - ymin);
+  p->nskip = (p->ymax - p->ymin) - (ymax - ymin);
   p->nmiss = p->nskip * (p->xmax - p->xmin);
 
   /* This is the outer loop over all the lines in the input image */
@@ -986,7 +987,7 @@ do_kernel_square(struct driz_param_t* p) {
       xyin[3][0] = (double) i - dh;
 
       for (ii = 0; ii < 4; ++ii) {
-        if (map_point(p->pixmap, xyin[ii], xyout)) {
+        if (map_point(p, xyin[ii], xyout)) {
             goto _miss;
         }
         xout[ii] = xyout[0];

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -391,7 +391,7 @@ append_vertex(struct polygon *p, struct vertex v) {
     if ((p->npv > 0) && equal_vertices(p->v[0], v, VERTEX_ATOL)) {
         return 1;
     }
-    if (p->npv >= 2 * IMAGE_OUTLINE_NPTS - 1) {
+    if (p->npv >= 2 * IMAGE_OUTLINE_NPTS) {
         return 1;
     }
     p->v[p->npv++] = v;

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -13,38 +13,12 @@
 #include "cdrizzlemap.h"
 #include "cdrizzleutil.h"
 
-/** --------------------------------------------------------------------------------------------------
- * Initialize a segment structure to contain the two points (x1, y1) and (x2, y2)
- * the invalid flag is initially set to 0 (valid)
- */
+#include <float.h>
 
-void
-initialize_segment(struct segment *self, integer_t x1, integer_t y1, integer_t x2, integer_t y2) {
-  self->point[0][0] = x1;
-  self->point[0][1] = y1;
-  self->point[1][0] = x2;
-  self->point[1][1] = y2;
-  self->invalid = 0;
+static const double VERTEX_ATOL = 1.0e-12;
+static const double APPROX_ZERO = 1.0e3 * DBL_MIN;
+static const double MAX_INV_ERR = 0.03;
 
-  return;
-}
-
-/** --------------------------------------------------------------------------------------------------
- * Generate a string representation of a segment for debugging
- *
- * self: the segment
- * str:  the string representation, at least 64 chars (output)
- */
-
-void
-show_segment(struct segment *self, char *str) {
-  sprintf(str, "(%10f,%10f) - (%10f,%10f) [%2d]",
-          self->point[0][0], self->point[0][1],
-          self->point[1][0], self->point[1][1],
-          self->invalid);
-
-  return;
-}
 
 /** --------------------------------------------------------------------------------------------------
  * Test if a pixmap vaue is bad (NaN)
@@ -88,132 +62,6 @@ bad_weight(PyArrayObject *weights, int i, int j) {
   }
 
   return 0;
-}
-
-/** --------------------------------------------------------------------------------------------------
- * Set the bounds of a segment to the range containing valid data
- *
- * self:    the segment
- * p:       the stucture containing the image pointers
- * pixmap:  array mapping input pixel coordinates to output pixel coordinates
- * weights: array of weights to apply when summing pixels
- */
-
-void
-shrink_segment(struct segment *self,
-               PyArrayObject *array,
-               int (*is_bad_value)(PyArrayObject *, int, int)) {
-
-  int i, j, imin, imax, jmin, jmax, i1, i2, j1, j2;
-
-  imin = self->point[1][0];
-  jmin = self->point[1][1];
-
-  j1 = (int) ceil(self->point[1][1]);
-  j2 = (int) self->point[0][1];
-  i1 = (int) ceil(self->point[1][0]);
-  i2 = (int) self->point[0][0];
-
-  for (j = j2; j < j1; ++j) {
-    for (i = i2; i < i1; ++i) {
-      if (! is_bad_value(array, i, j)) {
-        if (i < imin) {
-          imin = i;
-        }
-        if (j < jmin) {
-          jmin = j;
-        }
-        break;
-      }
-    }
-  }
-
-  imax = self->point[0][0];
-  jmax = self->point[0][1];
-  for (j = j1; j > j2; --j) {
-    for (i = i1; i > i2; --i) {
-      if (! is_bad_value(array, i-1, j-1)) {
-        if (i > imax) {
-          imax = i;
-        }
-        if (j > jmax) {
-          jmax = j;
-        }
-        break;
-      }
-    }
-  }
-  initialize_segment(self, imin, jmin, imax, jmax);
-  self->invalid = imin >= imax || jmin >= jmax;
-  return;
-}
-
-/** --------------------------------------------------------------------------------------------------
- * Sort points in increasing order on jdim coordinate
- *
- * self: the segment
- * jdim: the dimension to sort on, x (0) or y (1)
- */
-
-void
-sort_segment(struct segment *self, int jdim) {
-  int idim;
-
-  if (self->invalid == 0) {
-    if (self->point[0][jdim] > self->point[1][jdim]) {
-      double t;
-
-      for (idim = 0; idim < 2; ++idim) {
-        t = self->point[0][idim];
-        self->point[0][idim] = self->point[1][idim];
-        self->point[1][idim] = t;
-      }
-    }
-  }
-
-  return;
-}
-
-/** --------------------------------------------------------------------------------------------------
- * Take the the union of several line segments along a dimension.
- * That is, the result is the combined range of all the segments along a dimension
- *
- * npoint:   number of line segments to combine
- * jdim:     dimension to take union along, x (0) or y (1)
- * sybounds: the array of line segments
- * bounds:   union of the segment range (output)
- */
-
-void
-union_of_segments(int npoint, int jdim, struct segment xybounds[], integer_t bounds[2]) {
-  int ipoint;
-  int none = 1;
-
-  for (ipoint = 0; ipoint < npoint; ++ipoint) {
-    sort_segment(&xybounds[ipoint], jdim);
-
-    if (xybounds[ipoint].invalid == 0) {
-      integer_t lo = floor(xybounds[ipoint].point[0][jdim]);
-      integer_t hi = ceil(xybounds[ipoint].point[1][jdim]);
-
-      if (none == 0) {
-        if (lo < bounds[0]) bounds[0] = lo;
-        if (hi > bounds[1]) bounds[1] = hi;
-
-      } else {
-        none = 0;
-        bounds[0] = lo;
-        bounds[1] = hi;
-      }
-    }
-  }
-
-  if (none) {
-    bounds[0] = 0;
-    bounds[1] = 0;
-  }
-
-  return;
 }
 
 /** --------------------------------------------------------------------------------------------------
@@ -368,225 +216,691 @@ map_point(
   return status;
 }
 
-/** --------------------------------------------------------------------------------------------------
- * Clip a line segment from an input image to the limits of an output image along one dimension
- *
- * pixmap:   the mapping between input and output images
- * outlimit:  the limits  of the output image
- * xybounds: the clipped line segment (output)
- *
- */
+
+static int
+eval_inversion(PyArrayObject *pixmap, double x, double y,
+               double xyref[2], double *dist2) {
+    double xy[2], xyi[2], dx, dy;
+
+    xy[0] = x;
+    xy[1] = y;
+
+    if (interpolate_point(pixmap, xy, xyi)) {
+        return 1;
+    }
+    dx = xyi[0] - xyref[0];
+    dy = xyi[1] - xyref[1];
+    *dist2 = dx * dx + dy * dy;  // sqrt would be slower
+
+    return 0;
+}
+
 
 int
-clip_bounds(PyArrayObject *pixmap, struct segment *outlimit,
-            struct segment *xybounds) {
-  int ipoint, idim, jdim;
+invert_pixmap(PyArrayObject *pixmap, const double xyout[2], double xyin[2]) {
+    // invert input 'xyout' (output image) coordinates iteratively to the input
+    // image coordinates 'xyin' - output of this function.
 
-  if (xybounds->invalid) {
-    return 0;
-  }
+    const double gr = 0.6180339887498948482;  // Golden Ratio: (sqrt(5)-1)/2
+    const int nmax_iter = 50;
+    int nx, ny, niter;
+    double xmin, xmax, ymin, ymax, dx, dy, x1, x2, y1, y2;
+    double d11, d12, d21, d22;
+    npy_intp *ndim;
 
-  for (idim = 0; idim < 2; ++idim) {
-    for (ipoint = 0; ipoint < 2; ++ipoint) {
-      int m = 21;         /* maximum iterations */
-      int side = 0;       /* flag indicating which side moved last */
+    ndim = PyArray_DIMS(pixmap);
+    nx = ndim[1];
+    ny = ndim[0];
 
-      double xyin[2], xyout[2];
-      double a, b, c, fa, fb, fc;
+    xmin = -0.5;
+    xmax = (double) nx - 0.5;
+    ymin = -0.5;
+    ymax = (double) ny - 0.5;
+    dx = xmax;
+    dy = ymax;
 
-      /* starting values at endpoints of interval */
+    niter = 0;
 
-      for (jdim = 0; jdim < 2; ++jdim) {
-        xyin[jdim] = xybounds->point[0][jdim];
-      }
+    while ((dx > MAX_INV_ERR || dy > MAX_INV_ERR) && niter < nmax_iter) {
+        niter+=1;
 
-      if (map_point(pixmap, xyin, xyout)) {
-        /* Cannot find bound */
-        return 0;
-      }
+        x1 = xmax - gr * dx;
+        x2 = xmin + gr * dx;
+        y1 = ymax - gr * dy;
+        y2 = ymin + gr * dy;
 
-      a = xybounds->point[0][idim];
-      fa = xyout[idim] - outlimit->point[ipoint][idim];
+        if (eval_inversion(pixmap, x1, y1, xyout, &d11)) return 1;
+        if (eval_inversion(pixmap, x1, y2, xyout, &d12)) return 1;
+        if (eval_inversion(pixmap, x2, y1, xyout, &d21)) return 1;
+        if (eval_inversion(pixmap, x2, y2, xyout, &d22)) return 1;
 
-      for (jdim = 0; jdim < 2; ++jdim) {
-        xyin[jdim] = xybounds->point[1][jdim];
-      }
-
-      if (map_point(pixmap, xyin, xyout)) {
-        /* Cannot find bound */
-        return 0;
-      }
-
-      c = xybounds->point[1][idim];
-      fc = xyout[idim] - outlimit->point[ipoint][idim];
-
-      /* Solution via the method of false position (regula falsi) */
-
-      if (fa * fc < 0.0) {
-        int n; /* for loop limit is just for safety's sake */
-
-        xybounds->invalid = 0;
-        for (n = 0; n < m; n++) {
-          b = (fa * c - fc * a) / (fa - fc);
-
-          /* Solution is exact if within a pixel because linear interpolation */
-          if (floor(a) == floor(c)) break;
-
-          xyin[idim] = b;
-          if (map_point(pixmap, xyin, xyout)) {
-            /*  cannot map point, so end interpolation */
-            break;
-          }
-          fb = xyout[idim] - outlimit->point[ipoint][idim];
-
-          /* Maintain the bound by copying b to the variable
-           * with the same sign as b
-           */
-
-          if (fb * fc > 0.0) {
-            c = b;
-            fc = fb;
-            if (side == -1) {
-                fa *= 0.5;
-            }
-            side = -1;
-
-          } else if (fa * fb > 0.0) {
-            a = b;
-            fa = fb;
-            if (side == +1) {
-                fc *= 0.5;
-            }
-            side = +1;
-
-          } else {
-            /* if the product is zero, we have converged */
-            break;
-          }
+        if (d11 < d12 && d11 < d21 && d11 < d22) {
+            xmax = x2;
+            ymax = y2;
+        } else if (d12 < d11 && d12 < d21 && d12 < d22) {
+            xmax = x2;
+            ymin = y1;
+        } else if (d21 < d11 && d21 < d12 && d21 < d22) {
+            xmin = x1;
+            ymax = y2;
+        } else {
+            xmin = x1;
+            ymin = y1;
         }
 
-        if (n > m) {
-          return 1;
-        }
-
-        xybounds->point[ipoint][idim] = b;
-
-      } else {
-        /* No bracket, so track which side the bound lies on */
-        if (xybounds->invalid == 0) {
-            xybounds->invalid = 1;
-        }
-        xybounds->invalid *= fa > 0.0 ? +1 : -1;
-      }
+        dx = xmax - xmin;
+        dy = ymax - ymin;
     }
 
-    if (xybounds->invalid > 0) {
-      /* Positive means both bounds are outside the image */
-      xybounds->point[1][idim] = xybounds->point[0][idim];
-      break;
+    xyin[0] = 0.5 * (xmin + xmax);
+    xyin[1] = 0.5 * (ymin + ymax);
 
+    if (niter == nmax_iter) return 1;
+
+    return 0;
+}
+
+
+// computes modulus of a % b  (with b > 0) similar to Python. A more robust
+// approach would be to do this: (((a % b) + b) % b). However the polygon
+// intersection code will never have a < -1 and so a simplified and faster
+// version was implemented that works for a >= -b.
+inline int
+mod(int a, int b) {
+    return ((a + b) % b);
+    // return (((a % b) + b) % b);
+}
+
+// test whether two vertices (points) are equal to within a specified
+// absolute tolerance
+static inline int
+equal_vertices(struct vertex a, struct vertex b, double atol) {
+    return (fabs(a.x - b.x) < atol && fabs(a.y - b.y) < atol);
+}
+
+// Z-axis/k-component of the cross product a x b
+static inline double
+area(struct vertex a, struct vertex b) {
+    return (a.x * b.y - a.y * b.x);
+}
+
+
+// tests whether a point is in a half-plane of the vector going from
+// vertex v_ to vertex v (including the case of the point lying on the
+// vector (v_, v)). Specifically, it tests (v - v_) x (pt - v_) >= 0:
+static inline int
+is_point_in_hp(struct vertex pt, struct vertex v_, struct vertex v) {
+    // (v - v_) x (pt - v_) = v x pt - v x v_ - v_ x pt + v_ x v_ =
+    // = v x pt - v x v_ - v_ x pt
+    return ((area(v, pt) - area(v_, pt) - area(v, v_)) >= -APPROX_ZERO);
+}
+
+
+// same as is_point_in_hp but tests strict inequality (point not on the vector)
+static inline int
+is_point_strictly_in_hp(const struct vertex pt, const struct vertex v_,
+                        const struct vertex v) {
+    return ( (area(v, pt) - area(v_, pt) - area(v, v_)) > APPROX_ZERO );
+}
+
+
+// returns 1 if all vertices from polygon p are inside polygon q or 0 if
+// at least one vertex of p is outside of q.
+static inline int
+is_poly_contained(const struct polygon *p, const struct polygon *q) {
+    int i, j;
+    struct vertex *v_, *v;
+
+    v_ = q->v + (q->npv - 1);
+    v = q->v;
+
+    for (i = 0; i < q->npv; i++) {
+        for (j = 0; j < p->npv; j++) {
+            if (!is_point_in_hp(p->v[j], *v_, *v)) {
+                return 0;
+            }
+        }
+        v_ = v;
+        v++;
+    }
+
+    return 1;
+}
+
+
+// Append a vertex to the polygon's list of vertices and increment
+// vertex count.
+// return 1 if storage capacity is exceeded or 0 on success
+static int
+append_vertex(struct polygon *p, struct vertex v) {
+    if ((p->npv > 0) && equal_vertices(p->v[p->npv - 1], v, VERTEX_ATOL)) {
+        return 0;
+    }
+    if ((p->npv > 0) && equal_vertices(p->v[0], v, VERTEX_ATOL)) {
+        return 1;
+    }
+    if (p->npv >= 2 * IMAGE_OUTLINE_NPTS - 1) {
+        return 1;
+    }
+    p->v[p->npv++] = v;
+    return 0;
+}
+
+
+// remove midpoints (if any) - vertices that lie on a line connecting
+// other two vertices
+static void
+simplify_polygon(struct polygon *p) {
+    struct polygon pqhull;
+    struct vertex dp, dq, *pv, *pv_, *pvnxt;
+    int k;
+
+    if (p->npv < 3) return;
+
+    pqhull.npv = 0;
+
+    pv_ = (struct vertex *)(p->v) + (p->npv - 1);
+    pv = (struct vertex *)p->v;
+    pvnxt = ((struct vertex *)p->v) + 1;
+
+    for (k = 0; k < p->npv; k++) {
+        dp.x = pvnxt->x - pv_->x;
+        dp.y = pvnxt->y - pv_->y;
+        dq.x = pv->x - pv_->x;
+        dq.y = pv->y - pv_->y;
+
+        if (fabs(area(dp, dq)) > APPROX_ZERO &&
+            sqrt(dp.x * dp.x + dp.y * dp.y) > VERTEX_ATOL) {
+            pqhull.v[pqhull.npv++] = *pv;
+        }
+        pv_ = pv;
+        pv = pvnxt;
+        pvnxt = ((struct vertex *)p->v) + (mod(2 + k, p->npv));
+    }
+
+    p->npv = pqhull.npv;
+    for (k = 0; k < p->npv; k++) {
+        p->v[k] = pqhull.v[k];
+    }
+}
+
+
+int
+intersect_convex_polygons(const struct polygon *p, const struct polygon *q,
+                          struct polygon *pq) {
+
+    int ip=0, iq=0, first_k, k;
+    int inside=0;  // 0 - not set, 1 - "P", -1 - "Q"
+    int pv_in_hpdq, qv_in_hpdp;
+    struct vertex *pv, *pv_, *qv, *qv_, dp, dq, vi, first_intersect;
+    double t, u, d, dot, signed_area;
+
+    if ((p->npv < 3) || (q->npv < 3)) {
+        return 1;
+    }
+
+    if (is_poly_contained(p, q)) {
+        *pq = *p;
+        simplify_polygon(pq);
+        return 0;
+    } else if (is_poly_contained(q, p)) {
+        *pq = *q;
+        simplify_polygon(pq);
+        return 0;
+    }
+
+    pv_ = (struct vertex *)(p->v + (p->npv - 1));
+    pv = (struct vertex *)p->v;
+    qv_ = (struct vertex *)(q->v + (q->npv - 1));
+    qv = (struct vertex *)q->v;
+
+    first_k = -2;
+    pq->npv = 0;
+
+    for (k = 0; k <= 2 * (p->npv + q->npv); k++) {
+        dp.x = pv->x - pv_->x;
+        dp.y = pv->y - pv_->y;
+        dq.x = qv->x - qv_->x;
+        dq.y = qv->y - qv_->y;
+
+        // https://en.wikipedia.org/wiki/Line–line_intersection
+        t = (pv_->y - qv_->y) * dq.x - (pv_->x - qv_->x) * dq.y;
+        u = (pv_->y - qv_->y) * dp.x - (pv_->x - qv_->x) * dp.y;
+        signed_area = area(dp, dq);
+        if (signed_area >= 0.0) {
+            d = signed_area;
+        } else {
+            t = -t;
+            u = -u;
+            d = -signed_area;
+        }
+
+        pv_in_hpdq = is_point_strictly_in_hp(*qv_, *qv, *pv);
+        qv_in_hpdp = is_point_strictly_in_hp(*pv_, *pv, *qv);
+
+        if ((0.0 <= t) && (t <= d) && (0.0 <= u) && (u <= d) &&
+            (d > APPROX_ZERO)) {
+            t = t / d;
+            u = u / d;
+            vi.x = pv_->x + (pv->x - pv_->x) * t;
+            vi.y = pv_->y + (pv->y - pv_->y) * t;
+
+            if (first_k < 0) {
+                first_intersect = vi;
+                first_k = k;
+                if (append_vertex(pq, vi)) break;
+            } else if (equal_vertices(first_intersect, vi, VERTEX_ATOL)) {
+                if (k > (first_k + 1)) {
+                    break;
+                }
+                first_k = k;
+            } else {
+                if (append_vertex(pq, vi)) break;
+            }
+
+            if (pv_in_hpdq) {
+                inside = 1;
+            } else if (qv_in_hpdp) {
+                inside = -1;
+            }
+        }
+
+        // advance:
+        if (d < 1.0e-12 && !pv_in_hpdq && !qv_in_hpdp) {
+            if (inside == 1) {
+                iq += 1;
+                qv_ = qv;
+                qv = q->v + mod(iq, q->npv);
+            } else {
+                ip += 1;
+                pv_ = pv;
+                pv = p->v + mod(ip, p->npv);
+            }
+
+        } else if (signed_area >= 0.0) {
+            if (qv_in_hpdp) {
+                if (inside == 1) {
+                    if (append_vertex(pq, *pv)) break;
+                }
+                ip += 1;
+                pv_ = pv;
+                pv = p->v + mod(ip, p->npv);
+            } else {
+                if (inside == -1) {
+                    if (append_vertex(pq, *qv)) break;
+                }
+                iq += 1;
+                qv_ = qv;
+                qv = q->v + mod(iq, q->npv);
+            }
+
+        } else {
+            if (pv_in_hpdq) {
+                if (inside == -1) {
+                    if (append_vertex(pq, *qv)) break;
+                }
+                iq += 1;
+                qv_ = qv;
+                qv = q->v + mod(iq, q->npv);
+            } else {
+                if (inside == 1) {
+                    if (append_vertex(pq, *pv)) break;
+                }
+                ip += 1;
+                pv_ = pv;
+                pv = p->v + mod(ip, q->npv);
+            }
+        }
+    }
+
+    simplify_polygon(pq);
+
+    return 0;
+}
+
+
+static void
+init_edge(struct edge *e, struct vertex v1, struct vertex v2, int position) {
+    e->v1 = v1;
+    e->v2 = v2;
+    e->p = position;  // -1 for left-side edge and +1 for right-side edge
+    e->m = (v2.x - v1.x) / (v2.y - v1.y);
+    e->b = (v1.x * v2.y - v1.y * v2.x) / (v2.y - v1.y);
+    e->c = e->b - copysign(0.5 + 0.5 * fabs(e->m), (double) position);
+};
+
+
+/*
+bbox = [[xmin, xmax], [ymin, ymax]]
+*/
+int
+init_scanner(struct polygon *p, struct scanner *s,
+             int image_width, int image_height) {
+    int k, i1, i2;
+    int min_right, min_left, max_right, max_left;
+    double min_y, max_y;
+
+    s->left = NULL;
+    s->right = NULL;
+    s->nleft = 0;
+    s->nright = 0;
+
+    if (p->npv < 3) {
+        // not a polygon
+        return 1;
+    }
+
+    // find minimum/minima:
+    min_y = p->v[0].y;
+    min_left = 0;
+    for (k = 1; k < p->npv; k++) {
+        if (p->v[k].y < min_y) {
+            min_left = k;
+            min_y = p->v[k].y;
+        }
+    }
+
+    i1 = mod(min_left - 1, p->npv);
+    i2 = mod(min_left + 1, p->npv);
+    min_right = ( p->v[i1].y < p->v[i2].y ) ? i1 : i2;
+    if (p->v[min_right].y <= min_y * (1.0 + copysign(VERTEX_ATOL, min_y))) {
+        if (p->v[min_left].x > p->v[min_right].x) {
+            k = min_left;
+            min_left = min_right;
+            min_right = k;
+        }
     } else {
-      /* Negative means both bounds are inside, which is not a problem */
-      xybounds->invalid = 0;
+        min_right = min_left;
     }
-  }
 
-  return 0;
+    // find maximum/maxima:
+    max_y = p->v[0].y;
+    max_right = 0;
+    for (k = 1; k < p->npv; k++) {
+        if (p->v[k].y > max_y) {
+            max_right = k;
+            max_y = p->v[k].y;
+        }
+    }
+
+    i1 = mod(max_right - 1, p->npv);
+    i2 = mod(max_right + 1, p->npv);
+    max_left = ( p->v[i1].y > p->v[i2].y ) ? i1 : i2;
+    if (p->v[max_left].y >= max_y * (1.0 - copysign(VERTEX_ATOL, max_y))) {
+        if (p->v[max_left].x > p->v[max_right].x) {
+            k = max_left;
+            max_left = max_right;
+            max_right = k;
+        }
+    } else {
+        max_left = max_right;
+    }
+
+    // Left: start with minimum and move counter-clockwise:
+    if (max_left > min_left) {
+        min_left += p->npv;
+    }
+    s->nleft = min_left - max_left;
+
+    for (k = 0; k < s->nleft; k++) {
+        i1 = mod(min_left - k, p->npv);
+        i2 = mod(i1 - 1, p->npv);
+        init_edge(s->left_edges + k, p->v[i1], p->v[i2], -1);
+    }
+
+    // Right: start with minimum and move clockwise:
+    if (max_right < min_right) {
+        max_right += p->npv;
+    }
+    s->nright = max_right - min_right;
+
+    for (k = 0; k < s->nright; k++) {
+        i1 = mod(min_right + k, p->npv);
+        i2 = mod(i1 + 1, p->npv);
+        init_edge(s->right_edges + k, p->v[i1], p->v[i2], 1);
+    }
+
+    s->left = (struct edge *) s->left_edges;
+    s->right = (struct edge *) s->right_edges;
+    s->ymin = min_y;
+    s->ymax = max_y;
+    s->width = image_width;
+    s->height = image_height;
+
+    return 0;
 }
 
-/** --------------------------------------------------------------------------------------------------
- * Determine the range of pixels in a specified line of an input image
- * which are inside the output image. Range is one-sided, that is, the second
- * value returned is one greater than the last pixel that is on the image.
- *
- * p:       the stucture containing the image pointers
- * margin:  a margin in pixels added to the limits
- * j:       the index of the line in the input image whose range is computed
- * xbounds: the input pixels bounding the overlap (output)
- */
+/*
+get_scanline_limits returns x-limits for an image row that fits between edges
+(of a polygon) specified by the scanner structure.
+
+This function is intended to be called successively with input 'y' *increasing*
+from s->ymin to s->ymax.
+
+Return code:
+    0 - no errors
+    1 - scan ended (y reached the top vertex/edge)
+    2 - pixel centered on y is outside of scanner's limits or image [0, height - 1]
+    3 - limits (x1, x2) are equal (line with is 0)
+
+*/
+int
+get_scanline_limits(struct scanner *s, int y, int *x1, int *x2) {
+    double pyb, pyt;  // pixel top and bottom limits
+    double xlb, xlt, xrb, xrt, edge_ymax;
+    struct edge *el_max, *er_max;
+
+    el_max = ((struct edge *) s->left_edges) + (s->nleft - 1);
+    er_max = ((struct edge *) s->right_edges) + (s->nright - 1);
+
+    if (s->height >= 0 && (y < 0 || y >= s->height)) {
+        return 2;
+    }
+
+    pyb = (double)y - 0.5;
+    pyt = (double)y + 0.5;
+
+    if (pyt <= s->ymin || pyb >= s->ymax + 1) {
+        return 2;
+    }
+
+    if (s->left == NULL || s->right == NULL) {
+        return 1;
+    }
+
+    while (pyb > s->left->v2.y) {
+        if (s->left == el_max) {
+            s->left = NULL;
+            s->right = NULL;
+            return 1;
+        }
+        ++s->left;
+    };
+
+    while (pyb > s->right->v2.y) {
+        if (s->right == er_max) {
+            s->left = NULL;
+            s->right = NULL;
+            return 1;
+        }
+        ++s->right;
+    };
+
+    /* For double precision:
+    xlb = s->left->m * y + s->left->c;
+    xrb = s->right->m * y + s->right->c;
+    */
+    xlb = (int)round(s->left->m * y + s->left->c + 0.0);
+    xrb = (int)round(s->right->m * y + s->right->c + 0.0);
+    xlb = s->left->m * y + s->left->c - MAX_INV_ERR;
+    xrb = s->right->m * y + s->right->c + MAX_INV_ERR;
+
+    edge_ymax = s->left->v2.y + 0.5 + MAX_INV_ERR;
+    while (pyt > edge_ymax) {
+        if (s->left == el_max) {
+            s->left = NULL;
+            s->right = NULL;
+            return 1;
+        }
+        ++s->left;
+        edge_ymax = s->left->v2.y + 0.5 + MAX_INV_ERR;
+    };
+
+    edge_ymax = s->right->v2.y + 0.5 + MAX_INV_ERR;
+    while (pyt > edge_ymax) {
+        if (s->right == er_max) {
+            s->left = NULL;
+            s->right = NULL;
+            return 1;
+        }
+        ++s->right;
+        edge_ymax = s->right->v2.y + 0.5 + MAX_INV_ERR;
+    };
+
+    /* For double precision:
+    xlt = s->left->m * y + s->left->c;
+    xrt = s->right->m * y + s->right->c;
+    */
+    xlt = (int)(s->left->m * y + s->left->c + 0.5 + MAX_INV_ERR);
+    xrt = (int)(s->right->m * y + s->right->c + 0.5 + MAX_INV_ERR);
+    xlt = s->left->m * y + s->left->c - MAX_INV_ERR;
+    xrt = s->right->m * y + s->right->c + MAX_INV_ERR;
+
+    if (s->width >= 0) {
+        if (xlb < -0.5) {
+            xlb = -0.5;
+        }
+        if (xlt < -0.5) {
+            xlt = -0.5;
+        }
+        if (xrb >= s->width) {
+            xrb = s->width - 0.5;
+        }
+        if (xrt >= s->width) {
+            xrt = s->width - 0.5;
+        }
+    }
+
+    if (xlt >= xrt) {
+        *x1 = (int)round(xlb);
+        *x2 = (int)round(xrb);
+        if (xlb >= xrb) {
+            return 3;
+        }
+    } else if (xlb >= xrb) {
+        *x1 = (int)round(xlt);
+        *x2 = (int)round(xrt);
+    } else {
+        *x1 = (int)round((xlb > xlt) ? xlb : xlt);
+        *x2 = (int)round((xrb < xrt) ? xrb : xrt);
+    }
+
+    return 0;
+}
+
+
+static int
+map_to_output_vertex(struct driz_param_t* par, double x, double y, struct vertex *v) {
+    double xyin[2], xyout[2];
+    // convert coordinates to the output frame
+    xyin[0] = x;
+    xyin[1] = y;
+    if (map_point(par->pixmap, xyin, xyout)) {
+        driz_error_set_message(par->error,
+            "error computing input image bounding box");
+        return 1;
+    }
+    v->x = xyout[0];
+    v->y = xyout[1];
+    return 0;
+}
+
+
+static int
+map_to_input_vertex(struct driz_param_t* par, double x, double y, struct vertex *v) {
+    double xyin[2], xyout[2];
+    char buf[MAX_DRIZ_ERROR_LEN];
+    int n;
+    // convert coordinates to the input frame
+    xyout[0] = x;
+    xyout[1] = y;
+    if (invert_pixmap(par->pixmap, xyout, xyin)) {
+        n = sprintf(buf,
+            "failed to invert pixel map at position (%.2f, %.2f)", x, y);
+        if (n < 0) {
+            strcpy(buf, "failed to invert pixel map");
+        }
+        driz_error_set_message(par->error, buf);
+        return 1;
+    }
+    v->x = xyin[0];
+    v->y = xyin[1];
+    return 0;
+}
+
 
 int
-check_line_overlap(struct driz_param_t* p, int margin, integer_t j, integer_t *xbounds) {
-  struct segment outlimit, xybounds;
-  integer_t isize[2], osize[2];
+init_image_scanner(struct driz_param_t* par, struct scanner *s,
+                   int *ymin, int *ymax) {
+    struct polygon p, q, pq, inpq;
+    double  xyin[2], xyout[2];
+    integer_t isize[2], osize[2];
+    int ipoint;
+    int k, n;
+    npy_intp *ndim;
+    int ixmin, ixmax, iymin, iymax, in_width, in_height;
 
-  get_dimensions(p->output_data, osize);
-  initialize_segment(&outlimit, - margin, - margin,
-                     osize[0] + margin, osize[1] + margin);
+    // find smallest bounding box for the input image:
+    ndim = PyArray_DIMS(par->data);
+    in_width = ndim[1];
+    in_height = ndim[0];
+    ixmin = par->xmin > 0 ? (int)par->xmin : 0;
+    ixmax = ndim[1] - 1;
+    if (ixmax > (int)par->xmax) ixmax = (int)par->xmax;
 
-  initialize_segment(&xybounds, p->xmin, j, p->xmax, j+1);
-  shrink_segment(&xybounds, p->pixmap, &bad_pixel);
+    iymin = par->ymin > 0 ? (int)par->ymin : 0;
+    iymax = ndim[0] - 1;
+    if (iymax > (int)par->ymax) iymax = (int)par->ymax;
 
-  if (clip_bounds(p->pixmap, &outlimit, &xybounds)) {
-    driz_error_set_message(p->error, "cannot compute xbounds");
-    return 1;
-  }
+    // convert coordinates to the output frame and define a polygon
+    // bounding the input image in the output frame:
+    if (map_to_output_vertex(par, ixmin - 0.5, iymin - 0.5, p.v)) return 1;
+    if (map_to_output_vertex(par, ixmax + 0.5, iymin - 0.5, p.v + 1)) return 1;
+    if (map_to_output_vertex(par, ixmax + 0.5, iymax + 0.5, p.v + 2)) return 1;
+    if (map_to_output_vertex(par, ixmin - 0.5, iymax + 0.5, p.v + 3)) return 1;
+    p.npv = 4;
 
-  sort_segment(&xybounds, 0);
-  shrink_segment(&xybounds, p->weights, &bad_weight);
+    // define a polygon bounding output image:
+    ndim = PyArray_DIMS(par->output_data);
+    q.npv = 4;
+    q.v[0].x = -0.5;
+    q.v[0].y = -0.5;
+    q.v[1].x = ndim[1] - 0.5;
+    q.v[1].y = -0.5;
+    q.v[2].x = ndim[1] - 0.5;
+    q.v[2].y = ndim[0] - 0.5;
+    q.v[3].x = -0.5;
+    q.v[3].y = ndim[0] - 0.5;
 
-  xbounds[0] = floor(xybounds.point[0][0]);
-  xbounds[1] = ceil(xybounds.point[1][0]);
-
-  get_dimensions(p->data, isize);
-  if (driz_error_check(p->error, "xbounds must be inside input image",
-                       xbounds[0] >= 0 && xbounds[1] <= isize[0])) {
-    return 1;
-
-  } else {
-    return 0;
-  }
-}
-
-/** --------------------------------------------------------------------------------------------------
- * Determine the range of lines in the input image that overlap the output image
- * Range is one-sided, that is, the second value returned is one greater than the
- * last line that is on the image.
- *
- * p:       the stucture containing the image pointers
- * margin:  a margin in pixels added to the limits
- * ybounds: the input lines bounding the overlap (output)
- */
-
-int
-check_image_overlap(struct driz_param_t* p, const int margin, integer_t *ybounds) {
-
-  struct segment inlimit, outlimit, xybounds[2];
-  integer_t isize[2], osize[2];
-  int ipoint;
-
-  get_dimensions(p->output_data, osize);
-  initialize_segment(&outlimit, - margin, - margin,
-                     osize[0] + margin, osize[1] + margin);
-
-  initialize_segment(&inlimit, p->xmin, p->ymin, p->xmax, p->ymax);
-  shrink_segment(&inlimit, p->pixmap, &bad_pixel);
-
-  if (inlimit.invalid == 1) {
-      driz_error_set_message(p->error, "no valid pixels on input image");
-      return 1;
+    // compute intersection of P and Q (in output frame):
+    if (intersect_convex_polygons(&p, &q, &pq)) {
+        driz_error_set_message(par->error,
+            "failed to compute polygon intersection");
+        return 1;
     }
 
-  for (ipoint = 0; ipoint < 2; ++ipoint) {
-    initialize_segment(&xybounds[ipoint],
-                       inlimit.point[ipoint][0], inlimit.point[0][1],
-                       inlimit.point[ipoint][0], inlimit.point[1][1]);
-
-    if (clip_bounds(p->pixmap, &outlimit, &xybounds[ipoint])) {
-      driz_error_set_message(p->error, "cannot compute ybounds");
-      return 1;
+    // convert coordinates of vertices of the intersection polygon
+    // back to input image coordinate system:
+    for (k = 0; k < pq.npv; k++) {
+        if (map_to_input_vertex(par, pq.v[k].x, pq.v[k].y, &inpq.v[k])) {
+            return 1;
+        }
     }
-  }
+    inpq.npv = pq.npv;
 
-  union_of_segments(2, 1, xybounds, ybounds);
-
-  get_dimensions(p->pixmap, isize);
-  if (driz_error_check(p->error, "ybounds must be inside input image",
-                       ybounds[0] >= 0 && ybounds[1] <= isize[1])) {
-    return 1;
-
-  } else {
-    return 0;
-  }
+    // initialize polygon scanner:
+    n = init_scanner(&inpq, s, in_width, in_height);
+    *ymin = MAX(0, (int)(s->ymin + 0.5 + 2.0 * MAX_INV_ERR));
+    *ymax = MIN(in_height - 1, (int)(s->ymax + 2.0 * MAX_INV_ERR));
+    return n;
 }
-

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -65,6 +65,62 @@ bad_weight(PyArrayObject *weights, int i, int j) {
 }
 
 
+int
+shrink_image_section(PyArrayObject *pixmap, int *xmin, int *xmax,
+                     int *ymin, int *ymax) {
+    int i, j, imin, imax, jmin, jmax, i1, i2, j1, j2;
+    double *pv;
+
+    j1 = *ymin;
+    j2 = *ymax;
+    i1 = *xmin;
+    i2 = *xmax;
+
+    imin = i2;
+    jmin = j2;
+
+    for (j = j1; j <= j2; ++j) {
+        for (i = i1; i <= i2; ++i) {
+            pv = (double *) PyArray_GETPTR3(pixmap, j, i, 0);
+            if (!(npy_isnan(pv[0]) || npy_isnan(pv[1]))) {
+                if (i < imin) {
+                    imin = i;
+                }
+                if (j < jmin) {
+                    jmin = j;
+                }
+                break;
+            }
+        }
+    }
+
+    imax = imin;
+    jmax = jmin;
+
+    for (j = j2; j >= j1; --j) {
+        for (i = i2; i >= i1; --i) {
+            pv = (double *) PyArray_GETPTR3(pixmap, j, i, 0);
+            if (!(npy_isnan(pv[0]) || npy_isnan(pv[1]))) {
+                if (i > imax) {
+                    imax = i;
+                }
+                if (j > jmax) {
+                    jmax = j;
+                }
+                break;
+            }
+        }
+    }
+
+    *xmin = imin;
+    *xmax = imax;
+    *ymin = jmin;
+    *ymax = jmax;
+
+    return (imin >= imax || jmin >= jmax);
+}
+
+
 /** ---------------------------------------------------------------------------
  * Map a point on the input image to the output image using
  * a mapping of the pixel centers between the two by interpolating

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -19,7 +19,24 @@ static const double VERTEX_ATOL = 1.0e-12;
 static const double APPROX_ZERO = 1.0e3 * DBL_MIN;
 static const double MAX_INV_ERR = 0.03;
 
-
+/** ---------------------------------------------------------------------------
+ * Find the tighest bounding box around valid (finite) pixmap values.
+ *
+ * This function takes as input a pixel map array and four values indicating
+ * some given bounding box defined by: xmin, xmax, ymin, ymax. Starting with
+ * these values, this function checks values of pixel map on the border and
+ * if there are no valid values along one or more edges, it will adjust the
+ * values of xmin, xmax, ymin, ymax to find the tightest box that has
+ * at least one valid pixel on every edge of the bounding box.
+ *
+ * @param[in] PyArrayObject *pixmap - pixel map of shape (N, M, 2).
+ * @param[in,out] int xmin - position of the left edge of the bounding box.
+ * @param[in,out] int xmax - position of the right edge of the bounding box.
+ * @param[in,out] int ymin - position of the bottom edge of the bounding box.
+ * @param[in,out] int ymax - position of the top edge of the bounding box.
+ * @return 0 if successul and 1 if there is only one or no valid pixel map values.
+ *
+ */
 int
 shrink_image_section(PyArrayObject *pixmap, int *xmin, int *xmax,
                      int *ymin, int *ymax) {
@@ -170,7 +187,7 @@ map_pixel(PyArrayObject *pixmap, int i, int j, double *x, double *y) {
 
 /** ---------------------------------------------------------------------------
  * Map a point on the input image to the output image either by interpolation
- * or direct array acces if the input position is integral.
+ * or direct array access if the input position is integral.
  *
  * pixmap: The mapping of the pixel centers from input to output image
  * xin:   X-coordinate of a point on the input image
@@ -235,7 +252,7 @@ eval_inversion(struct driz_param_t *par, double x, double y,
 
 
 /** ---------------------------------------------------------------------------
- * Inverse mappting of coordinates from the output frame to input frame.
+ * Inverse mapping of coordinates from the output frame to input frame.
  *
  * Inverts input (xout, yout) (output image frame) coordinates iteratively
  * to the input image image frame (xin, yin) - the output of this function.
@@ -572,7 +589,7 @@ intersect_convex_polygons(const struct polygon *p, const struct polygon *q,
         if ((0.0 <= t) && (t <= d) && (0.0 <= u) && (u <= d) &&
             (d > APPROX_ZERO)) {
             t = t / d;
-            u = u / d;
+            // u = u / d;
             vi.x = pv_->x + (pv->x - pv_->x) * t;
             vi.y = pv_->y + (pv->y - pv_->y) * t;
 
@@ -756,27 +773,27 @@ init_scanner(struct polygon *p, struct driz_param_t* par, struct scanner *s) {
         max_left = max_right;
     }
 
-    // Left: start with minimum and move counter-clockwise:
+    // Left: start with minimum and move clockwise:
     if (max_left > min_left) {
         min_left += p->npv;
     }
     s->nleft = min_left - max_left;
 
     for (k = 0; k < s->nleft; k++) {
-        i1 = mod(min_left - k, p->npv);
-        i2 = mod(i1 - 1, p->npv);
+        i1 = mod(min_left - k, p->npv);  // -k for CW traverse direction
+        i2 = mod(i1 - 1, p->npv);  // -1 for CW traverse direction
         init_edge(s->left_edges + k, p->v[i1], p->v[i2], -1);
     }
 
-    // Right: start with minimum and move clockwise:
+    // Right: start with minimum and move counter-clockwise:
     if (max_right < min_right) {
         max_right += p->npv;
     }
     s->nright = max_right - min_right;
 
     for (k = 0; k < s->nright; k++) {
-        i1 = mod(min_right + k, p->npv);
-        i2 = mod(i1 + 1, p->npv);
+        i1 = mod(min_right + k, p->npv);  // +k for CW traverse direction
+        i2 = mod(i1 + 1, p->npv);  // +1 for CW traverse direction
         init_edge(s->right_edges + k, p->v[i1], p->v[i2], 1);
     }
 
@@ -922,7 +939,7 @@ get_scanline_limits(struct scanner *s, int y, int *x1, int *x2) {
 
 
 /**
- * Map a vertex' coordinates from input frame to the output frame.
+ * Map a vertex' coordinates from the input frame to the output frame.
  *
  * @param[in] struct driz_param_t - drizzle parameters (bounding box is used)
  * @param[in] struct vertex vin - vertex' coordinates in the input frame
@@ -939,7 +956,7 @@ map_vertex_to_output(struct driz_param_t* par, struct vertex vin,
 
 
 /**
- * Map a vertex' coordinates from input frame to the output frame.
+ * Map a vertex' coordinates from the output frame to the input frame.
  *
  * @param[in] struct driz_param_t - drizzle parameters (bounding box is used)
  * @param[in] struct vertex vout - vertex' coordinates in the output frame

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -90,7 +90,8 @@ int
 interpolate_point(struct driz_param_t *par, double xin, double yin,
                   double *xout, double *yout) {
     int ipix, jpix, npix, idim;
-    int i0, j0;
+    int i0, j0, nx2, ny2;
+    npy_intp *ndim;
     double x, y, x1, y1, f00, f01, f10, f11, g00, g01, g10, g11;
     double *p;
     PyArrayObject *pixmap;
@@ -103,16 +104,20 @@ interpolate_point(struct driz_param_t *par, double xin, double yin,
     i0 = (int)xin;
     j0 = (int)yin;
 
+    ndim = PyArray_DIMS(pixmap);
+    nx2 = (int)ndim[1] - 2;
+    ny2 = (int)ndim[0] - 2;
+
     // point is outside the interpolation range. adjust limits to extrapolate.
-    if (i0 < par->xmin) {
-        i0 = par->xmin;
-    } else if (i0 >= par->xmax) {
-        i0 = par->xmax - 1;
+    if (i0 < 0) {
+        i0 = 0;
+    } else if (i0 > nx2) {
+        i0 = nx2;
     }
-    if (j0 < par->ymin) {
-        j0 = par->ymin;
-    } else if (j0 >= par->ymax) {
-        j0 = par->ymax - 1;
+    if (j0 < 0) {
+        j0 = 0;
+    } else if (j0 > ny2) {
+        j0 = ny2;
     }
 
     x = xin - i0;

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -177,7 +177,7 @@ map_pixel(
 
 int
 map_pixel_fwd(PyArrayObject *pixmap, int i, int j, double *x, double *y) {
-    double *pv = pv = (double *) PyArray_GETPTR3(pixmap, j, i, 0);
+    double *pv = (double *) PyArray_GETPTR3(pixmap, j, i, 0);
     *x = *pv;
     *y = *(pv + 1);
     return ((npy_isnan(*x) || npy_isnan(*y)) ? 1 : 0);

--- a/src/cdrizzlemap.h
+++ b/src/cdrizzlemap.h
@@ -42,9 +42,9 @@ struct scanner {
     struct edge right_edges[2 * IMAGE_OUTLINE_NPTS];
     struct edge *left, *right;  // when set to NULL => done scanning
     int nleft, nright;
-    double ymin, ymax;  // bottom and top vertices
-    int width, height;  // image shape (width, height) - used for clipping
-                        // set width = height = -1 to not clip
+    double min_y, max_y;  // bottom and top vertices
+    int xmin, xmax, ymin, ymax;  // min/max x/y of valid pixels in pixmap;
+                                 // the bounding box (rounded to int)
 };
 
 int
@@ -60,7 +60,7 @@ bad_weight(PyArrayObject *weights,
            );
 
 int
-map_point(PyArrayObject * pixmap,
+map_point(struct driz_param_t* par,
           const double xyin[2],
           double xyout[2]
          );
@@ -73,15 +73,15 @@ map_pixel(PyArrayObject *pixmap,
          );
 
 int
-invert_pixmap(PyArrayObject *pixmap, const double xyout[2], double xyin[2]);
+invert_pixmap(struct driz_param_t* par,
+              const double xyout[2], double xyin[2]);
 
 int
 intersect_convex_polygons(const struct polygon *p, const struct polygon *q,
                           struct polygon *pq);
 
 int
-init_scanner(struct polygon *p, struct scanner *s,
-             int image_width, int image_height);
+init_scanner(struct polygon *p, struct scanner *s, struct driz_param_t* par);
 
 int
 get_scanline_limits(struct scanner *s, int y, int *x1, int *x2);

--- a/src/cdrizzlemap.h
+++ b/src/cdrizzlemap.h
@@ -45,19 +45,17 @@ struct scanner {
     double min_y, max_y;  // bottom and top vertices
     int xmin, xmax, ymin, ymax;  // min/max x/y of valid pixels in pixmap;
                                  // the bounding box (rounded to int)
+                                 // carried over from driz_param_t.
+    int overlap_valid;  // 1 - if polygon intersection and coord inversion
+                        //     worked;
+                        // 0 - if computation of xmin, xmax, ymin, ymax has
+                        //     failed in which case they are carried over from
+                        //     driz_param_t.
 };
 
 int
-bad_pixel(PyArrayObject *pixmap,
-          int i,
-          int j
-          );
-
-int
-bad_weight(PyArrayObject *weights,
-           int i,
-           int j
-           );
+interpolate_point(struct driz_param_t *par, double xin, double yin,
+                  double *xout, double *yout);
 
 int
 map_point(struct driz_param_t* par,

--- a/src/cdrizzlemap.h
+++ b/src/cdrizzlemap.h
@@ -73,6 +73,10 @@ map_pixel(PyArrayObject *pixmap,
          );
 
 int
+shrink_image_section(PyArrayObject *pixmap, int *xmin, int *xmax,
+                     int *ymin, int *ymax);
+
+int
 invert_pixmap(struct driz_param_t* par,
               const double xyout[2], double xyin[2]);
 

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -182,6 +182,7 @@ driz_param_dump(struct driz_param_t* p);
 #ifdef LOGGING
 extern FILE *driz_log_handle;
 
+
 static inline_macro FILE*
 driz_log_init(FILE *handle) {
     const char* dirs[] = {"TMPDIR", "TMP", "TEMP", "TEMPDIR"};

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -177,9 +177,9 @@ driz_param_dump(struct driz_param_t* p);
 /****************************************************************************/
 /* LOGGING */
 
-#define LOGGING 0
+#define LOGGING
 
-#if LOGGING
+#ifdef LOGGING
 extern FILE *driz_log_handle;
 
 static inline_macro FILE*
@@ -235,6 +235,7 @@ driz_log_idem(void *ptr) {
 #define driz_log_init(handle) driz_log_idem(handle)
 #define driz_log_close(handle) driz_log_idem(handle)
 #define driz_log_message(message) driz_log_idem(message)
+
 #endif
 
 /****************************************************************************/
@@ -259,28 +260,26 @@ get_pixmap(PyArrayObject *pixmap, integer_t xpix, integer_t ypix) {
   return (double*) PyArray_GETPTR3(pixmap, ypix, xpix, 0);
 }
 
-#if LOGGING
+#if defined(LOGGING) && defined(CHECK_OOB)
 
 static inline_macro int
 oob_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix) {
-  char buffer[64];
-  int flag = 0;
+    char buffer[64];
+    npy_intp *ndim = PyArray_DIMS(image);
+    if ((xpix < 0 || xpix >= ndim[1]) || (ypix < 0 || ypix >= ndim[0])) {
+        sprintf(buffer, "Point [%d,%d] is outside of [%d, %d]",
+                xpix, ypix, (int) ndim[1], (int) ndim[0]);
+        driz_log_message(buffer);
+        return 1;
+    }
 
-  npy_intp *ndim = PyArray_DIMS(image);
-  if (xpix < 0 || xpix >= ndim[1]) flag = 1;
-  if (ypix < 0 || ypix >= ndim[0]) flag = 1;
-
-  if (flag) {
-    sprintf(buffer, "Point [%d,%d] is outside of [%d, %d]",
-            xpix, ypix, (int) ndim[1], (int) ndim[0]);
-    driz_log_message(buffer);
-  }
-
-  return flag;
+    return 0;
 }
 
 #else
-#define oob_pixel(image, xpix, ypix)   0
+
+#define oob_pixel(image, xpix, ypix) 0
+
 #endif
 
 static inline_macro float

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -423,19 +423,19 @@ FCT_BGN_FN(utest_cdrizzle)
 
         FCT_TEST_BGN(utest_map_point_01)
         {
-            double xyin[2], xyout[2];
+            double ix, iy, ox, oy;
             struct driz_param_t *p;
 
             p = setup_parameters();
             stretch_pixmap(p, 1000.0);
 
-            xyin[0] = 2.5;
-            xyin[1] = 1.5;
+            ix = 2.5;
+            iy = 1.5;
 
-            map_point(p, xyin, xyout);
+            map_point(p, ix, iy, &ox, &oy);
 
-            fct_chk_eq_dbl(xyout[0], 2.5);
-            fct_chk_eq_dbl(xyout[1], 1500.0);
+            fct_chk_eq_dbl(ox, 2.5);
+            fct_chk_eq_dbl(oy, 1500.0);
 
             teardown_parameters(p);
         }
@@ -443,19 +443,19 @@ FCT_BGN_FN(utest_cdrizzle)
 
         FCT_TEST_BGN(utest_map_point_02)
         {
-            double xyin[2], xyout[2];
+            double ix, iy, ox, oy;
             struct driz_param_t *p;
 
             p = setup_parameters();
             stretch_pixmap(p, 1000.0);
 
-            xyin[0] = -1.0;
-            xyin[1] = 0.5;
+            ix = -1.0;
+            iy = 0.5;
 
-            map_point(p, xyin, xyout);
+            map_point(p, ix, iy, &ox, &oy);
 
-            fct_chk_eq_dbl(xyout[0], -1.0);
-            fct_chk_eq_dbl(xyout[1], 500.0);
+            fct_chk_eq_dbl(ox, -1.0);
+            fct_chk_eq_dbl(oy, 500.0);
 
             teardown_parameters(p);
         }
@@ -463,28 +463,28 @@ FCT_BGN_FN(utest_cdrizzle)
 
         FCT_TEST_BGN(utest_map_point_03)
         {
-            double xyin[2], xyout[2];
+            double ix, iy, ox, oy;
             int status;
             struct driz_param_t *p;
 
             p = setup_parameters();
             stretch_pixmap(p, 1000.0);
 
-            xyin[0] = 3.25;
-            xyin[1] = 5.0;
+            ix = 3.25;
+            iy = 5.0;
 
-            status = map_point(p, xyin, xyout);
+            status = map_point(p, ix, iy, &ox, &oy);
 
             fct_chk_int_return_status(status, 0);
-            fct_chk_eq_dbl(xyout[0], 3.25);
-            fct_chk_eq_dbl(xyout[1], 5000.0);
+            fct_chk_eq_dbl(ox, 3.25);
+            fct_chk_eq_dbl(oy, 5000.0);
 
             nan_pixel(p, 3, 5);
-            status = map_point(p, xyin, xyout);
+            status = map_point(p, ix, iy, &ox, &oy);
 
             fct_chk_int_return_status(status, 1);
-            fct_chk_neq_int(xyout[0], xyout[0]);
-            fct_chk_neq_int(xyout[1], xyout[1]);
+            fct_chk_neq_int(ox, ox);
+            fct_chk_neq_int(oy, oy);
 
             teardown_parameters(p);
         }
@@ -492,7 +492,7 @@ FCT_BGN_FN(utest_cdrizzle)
 
         FCT_TEST_BGN(utest_map_point_04)
         {
-            double xyin[2], xyout[2];
+            double ix, iy, ox, oy;
             int status;
             struct driz_param_t *p;
 
@@ -500,21 +500,21 @@ FCT_BGN_FN(utest_cdrizzle)
 
             stretch_pixmap(p, 1000.0);
 
-            xyin[0] = 0.25;
-            xyin[1] = 5.0;
+            ix = 0.25;
+            iy = 5.0;
 
-            status = map_point(p, xyin, xyout);
+            status = map_point(p, ix, iy, &ox, &oy);
 
             fct_chk_int_return_status(status, 0);
-            fct_chk_eq_dbl(xyout[0], 0.25);
-            fct_chk_eq_dbl(xyout[1], 5000.0);
+            fct_chk_eq_dbl(ox, 0.25);
+            fct_chk_eq_dbl(oy, 5000.0);
 
             nan_pixel(p, 0, 5);
-            status = map_point(p, xyin, xyout);
+            status = map_point(p, ix, iy, &ox, &oy);
 
             fct_chk_int_return_status(status, 1);
-            fct_chk_neq_int(xyout[0], xyout[0]);
-            fct_chk_neq_int(xyout[1], xyout[1]);
+            fct_chk_neq_int(ox, ox);
+            fct_chk_neq_int(oy, oy);
 
             teardown_parameters(p);
         }

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -326,6 +326,39 @@ FCT_BGN_FN(utest_cdrizzle)
         }
         FCT_TEARDOWN_END();
 
+        FCT_TEST_BGN(utest_shrink_bbox)
+        {
+            int xmin, xmax, ymin, ymax;
+            struct driz_param_t *p;     /* parameter structure */
+
+            p = setup_parameters();
+            nan_pixmap(p);
+
+            get_pixmap(p->pixmap, 16, 50)[0] = 16;
+            get_pixmap(p->pixmap, 16, 50)[1] = 50;
+            get_pixmap(p->pixmap, 85, 51)[0] = 85;
+            get_pixmap(p->pixmap, 85, 51)[1] = 51;
+            get_pixmap(p->pixmap, 57, 18)[0] = 57;
+            get_pixmap(p->pixmap, 57, 18)[1] = 18;
+            get_pixmap(p->pixmap, 47, 68)[0] = 47;
+            get_pixmap(p->pixmap, 47, 68)[1] = 68;
+
+            xmin = 11;
+            xmax = 98;
+            ymin = 7;
+            ymax = 88;
+
+            shrink_image_section(p->pixmap, &xmin, &xmax, &ymin, &ymax);
+
+            fct_chk_eq_int(xmin, 16);
+            fct_chk_eq_int(xmax, 85);
+            fct_chk_eq_int(ymin, 18);
+            fct_chk_eq_int(ymax, 68);
+
+            teardown_parameters(p);
+        }
+        FCT_TEST_END();
+
         FCT_TEST_BGN(utest_map_lookup_01)
         {
             struct driz_param_t *p;

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -260,9 +260,9 @@ setup_parameters() {
 
     p->uuid = 1;
     p->xmin = 0;
-    p->xmax = image_size[0];
+    p->xmax = image_size[0] - 1;
     p->ymin = 0;
-    p->ymax = image_size[1];
+    p->ymax = image_size[1] - 1;
     p->scale = 1.0;
     p->pixel_fraction = 1.0;
     p->exposure_time = 1.0;
@@ -399,7 +399,7 @@ FCT_BGN_FN(utest_cdrizzle)
             xyin[0] = 2.5;
             xyin[1] = 1.5;
 
-            map_point(p->pixmap, xyin, xyout);
+            map_point(p, xyin, xyout);
 
             fct_chk_eq_dbl(xyout[0], 2.5);
             fct_chk_eq_dbl(xyout[1], 1500.0);
@@ -419,7 +419,7 @@ FCT_BGN_FN(utest_cdrizzle)
             xyin[0] = -1.0;
             xyin[1] = 0.5;
 
-            map_point(p->pixmap, xyin, xyout);
+            map_point(p, xyin, xyout);
 
             fct_chk_eq_dbl(xyout[0], -1.0);
             fct_chk_eq_dbl(xyout[1], 500.0);
@@ -440,14 +440,14 @@ FCT_BGN_FN(utest_cdrizzle)
             xyin[0] = 3.25;
             xyin[1] = 5.0;
 
-            status = map_point(p->pixmap, xyin, xyout);
+            status = map_point(p, xyin, xyout);
 
             fct_chk_int_return_status(status, 0);
             fct_chk_eq_dbl(xyout[0], 3.25);
             fct_chk_eq_dbl(xyout[1], 5000.0);
 
             nan_pixel(p, 3, 5);
-            status = map_point(p->pixmap, xyin, xyout);
+            status = map_point(p, xyin, xyout);
 
             fct_chk_int_return_status(status, 1);
             fct_chk_neq_int(xyout[0], xyout[0]);
@@ -470,14 +470,14 @@ FCT_BGN_FN(utest_cdrizzle)
             xyin[0] = 0.25;
             xyin[1] = 5.0;
 
-            status = map_point(p->pixmap, xyin, xyout);
+            status = map_point(p, xyin, xyout);
 
             fct_chk_int_return_status(status, 0);
             fct_chk_eq_dbl(xyout[0], 0.25);
             fct_chk_eq_dbl(xyout[1], 5000.0);
 
             nan_pixel(p, 0, 5);
-            status = map_point(p->pixmap, xyin, xyout);
+            status = map_point(p, xyin, xyout);
 
             fct_chk_int_return_status(status, 1);
             fct_chk_neq_int(xyout[0], xyout[0]);


### PR DESCRIPTION
This is the second attempt to fix the issue described in https://github.com/spacetelescope/drizzle/pull/89. That fix was working only sometimes. This PR is a complete re-design of how `drizzle` computes image overlaps and scan lines.

Resolves #41
Resolves #63 
Fixes #87

Regression tests:
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/841
https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/872 (for 92b4deb)