### PR TITLE
use underscores in `upload_docs` config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,13 +56,13 @@ include-package-data = false
 namespaces = false
 
 [tool.build_docs]
-source-dir = "docs"
-build-dir = "docs/_build"
+source_dir = "docs"
+build_dir = "docs/_build"
 all_files = "1"
 
 [tool.distutils.upload_docs]
-upload-dir = "docs/_build/html"
-show-response = 1
+upload_dir = "docs/_build/html"
+show_response = 1
 
 [tool.pytest.ini_options]
 minversion = "4.6"


### PR DESCRIPTION
closes #106 

Note: entries in `tool.setuptools` DO use hyphens, not underscores (https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html)