### PR TITLE
Fix test failures on big endian architectures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,9 +4,13 @@
 Release Notes
 =============
 
-.. 1.14.1 (unreleased)
+.. 1.14.2 (unreleased)
    ===================
 
+1.14.1 (2023-09-16)
+===================
+
+- Addressed test failures on big endian architectures. [#116]
 
 
 1.14.0 (2023-09-15)

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -59,11 +59,11 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
 
   /* Arguments in the order they appear */
   PyObject *oimg, *owei, *pixmap, *oout, *owht, *ocon;
-  long uniqid = 1;
-  long xmin = 0;
-  long xmax = 0;
-  long ymin = 0;
-  long ymax = 0;
+  integer_t uniqid = 1;
+  integer_t xmin = 0;
+  integer_t xmax = 0;
+  integer_t ymin = 0;
+  integer_t ymax = 0;
   double scale = 1.0;
   double pfract = 1.0;
   char *kernel_str = "square";
@@ -89,9 +89,9 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
   driz_log_message("starting tdriz");
   driz_error_init(&error);
 
-  if (!PyArg_ParseTupleAndKeywords(args, keywords, "OOOOOO|lllllddssffs:tdriz", (char **)kwlist,
+  if (!PyArg_ParseTupleAndKeywords(args, keywords, "OOOOOO|iiiiiddssffs:tdriz", (char **)kwlist,
                         &oimg, &owei, &pixmap, &oout, &owht, &ocon, /* OOOOOO */
-                        &uniqid, &xmin, &xmax, &ymin, &ymax,  /* lllll */
+                        &uniqid, &xmin, &xmax, &ymin, &ymax,  /* iiiii */
                         &scale, &pfract, &kernel_str, &inun_str, /* ddss */
                         &expin, &wtscl,  &fillstr) /* ffs */
                        ) {


### PR DESCRIPTION
Fixes test failures on big endian architectures. The code in this PR is based on *analysis* of the code and it has not been tested on a big endian machine since I do not have access to one, at least not at this moment.

Closes #115 

@olebole Would it be possible for you to test this from this branch or would you prefer me making a release.

CC: @hbushouse @nden 
