### PR TITLE
Fix segfault on some systems

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,15 @@
 Release Notes
 =============
 
-.. 1.14.2 (unreleased)
+.. 1.14.4 (unreleased)
    ===================
+
+
+1.14.3 (2023-10-02)
+===================
+
+- Disable logging to fix a segfault on some systems. [#119]
+
 
 1.14.2 (2023-09-16)
 ===================

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -177,8 +177,6 @@ driz_param_dump(struct driz_param_t* p);
 /****************************************************************************/
 /* LOGGING */
 
-#define LOGGING
-
 #ifdef LOGGING
 extern FILE *driz_log_handle;
 
@@ -203,24 +201,32 @@ driz_log_init(FILE *handle) {
         }
     }
     if (!p) {
-        sprintf(buf, "%ctmp%cdrizzle.log", dirsep, dirsep);
+        sprintf(buf, "drizzle.log");
     }
 
     handle = fopen(buf, "a");
-    setbuf(handle, 0);
+    if (handle) {
+        setbuf(handle, 0);
+    }
     return handle;
 }
 
 
 static inline_macro int
 driz_log_close(FILE *handle) {
-    return fclose(driz_log_handle);
+    if (handle) {
+        return fclose(handle);
+    }
 }
 
 static inline_macro int
 driz_log_message(const char* message) {
-    if (! driz_log_handle)
+    if (!driz_log_handle) {
         driz_log_handle = driz_log_init(driz_log_handle);
+        if (!driz_log_handle) {
+            return 1;
+        }
+    }
 
     fputs(message, driz_log_handle);
     fputs("\n", driz_log_handle);


### PR DESCRIPTION
Disables logging by default and fixes issues with logging that were causing #118. In general, logging should be redesigned completely in the `drizzle` and this will be added to the TODO list.

NOTE: logging was disabled previously but was left enabled inadvertently during the work on polygon intersections.

Fixes #118 