### PR TITLE
Fix a bug in pixel inversion routine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Release Notes
 
 - Dropped Python 3.8. [#128]
 
+- Fixed a bug in the pixmap coordinate inversion routine. [#137]
+
 1.14.4 (2023-11-15)
 ===================
 

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -280,8 +280,8 @@ invert_pixmap(struct driz_param_t *par, double xout, double yout, double *xin,
     xmax = ((double)par->xmax) + 0.5;
     ymin = ((double)par->ymin) - 0.5;
     ymax = ((double)par->ymax) + 0.5;
-    dx = xmax;
-    dy = ymax;
+    dx = xmax - xmin;
+    dy = ymax - ymin;
 
     niter = 0;
 


### PR DESCRIPTION
Fixes a bug in the pixel coordinate inversion routine (from output frame to input frame). In part `fixes` #132 (first example).