### PR TITLE
[SCSB-145] require Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         - linux: check-style
         - linux: check-security
 
-        - linux: py39-xdist
         - linux: py310-xdist
         - linux: py311-xdist
         - macos: py312-xdist

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ the new GWCS code.
 Requirements
 ------------
 
-- Python 3.9 or later
+- Python 3.10 or later
 
 - Numpy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "drizzle"
 description = "A package for combining dithered images into a single image"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "STScI", email = "help@stsci.edu" },
 ]


### PR DESCRIPTION
resolves [SCSB-145](https://jira.stsci.edu/browse/SCSB-145)

propagate Astropy's deprecation of Python 3.9 to downstream packages


> [!NOTE]
> this PR was generated automatically by ``batchpr`` :robot: