### PR TITLE
apply `ruff format .` and `ruff check --fix .`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,6 @@
 # be accessible, and the documentation will not build correctly.
 
 import datetime
-import os
 import sys
 from pathlib import Path
 
@@ -48,7 +47,7 @@ if sys.version_info < (3, 11):
 else:
     import tomllib
 
-#sys.path.insert(0, os.path.abspath('../'))
+# sys.path.insert(0, os.path.abspath('../'))
 
 
 def find_mod_objs_patched(*args, **kwargs):
@@ -74,18 +73,18 @@ metadata = conf["project"]
 
 
 extensions = [
-    'sphinx_automodapi.automodapi',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
-    'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
+    "sphinx_automodapi.automodapi",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
 ]
 # -- General configuration ----------------------------------------------------
 
-master_doc = 'index'
+master_doc = "index"
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.2'
+# needs_sphinx = '1.2'
 
 # To perform a Sphinx version check that needs to be more specific than
 # major.minor, call `check_sphinx_version("x.y.z")` here.
@@ -93,7 +92,7 @@ master_doc = 'index'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_templates']
+exclude_patterns = ["_templates"]
 
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
@@ -103,9 +102,9 @@ rst_epilog = """
 # -- Project information ------------------------------------------------------
 
 # This does not *have* to match the package name, but typically does
-project = metadata['name']
-author = metadata['authors'][0]['name']
-copyright = f'{datetime.datetime.now().year}, {author }'
+project = metadata["name"]
+author = metadata["authors"][0]["name"]
+copyright = f"{datetime.datetime.now().year}, {author }"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -115,7 +114,7 @@ __import__(project)
 package = sys.modules[project]
 
 # The short X.Y version.
-version = package.__version__.split('-', 1)[0]
+version = package.__version__.split("-", 1)[0]
 # The full version, including alpha/beta/rc tags.
 release = package.__version__
 
@@ -131,44 +130,42 @@ release = package.__version__
 
 # Add any paths that contain custom themes here, relative to this directory.
 # To use a different custom theme, add the directory containing the theme.
-#html_theme_path = []
+# html_theme_path = []
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes. To override the custom theme, set this to the
 # name of a builtin theme or the name of a custom theme in html_theme_path.
-#html_theme = None
+# html_theme = None
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = ''
+# html_favicon = ''
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = ''
+# html_last_updated_fmt = ''
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = f'{project} v{release}'
+html_title = f"{project} v{release}"
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = project + 'doc'
+htmlhelp_basename = project + "doc"
 
 
 # -- Options for LaTeX output --------------------------------------------------
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
-latex_documents = [('index', project + '.tex', project + u' Documentation',
-                    author, 'manual')]
+latex_documents = [("index", project + ".tex", project + " Documentation", author, "manual")]
 
 
 # -- Options for manual page output --------------------------------------------
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [('index', project.lower(), project + u' Documentation',
-              [author], 1)]
+man_pages = [("index", project.lower(), project + " Documentation", [author], 1)]

--- a/drizzle/__init__.py
+++ b/drizzle/__init__.py
@@ -1,6 +1,7 @@
 """
 A package for combining dithered images into a single image
 """
+
 from importlib.metadata import PackageNotFoundError, version
 
 
@@ -8,4 +9,4 @@ try:
     __version__ = version(__name__)
 except PackageNotFoundError:
     # package is not installed
-    __version__ = 'unknown'
+    __version__ = "unknown"

--- a/drizzle/calc_pixmap.py
+++ b/drizzle/calc_pixmap.py
@@ -33,8 +33,8 @@ def calc_pixmap(first_wcs, second_wcs):
     # between the pixel co-ordinates in the first image to pixel co-ordinates in the
     # co-ordinate system of the second.
 
-    one = np.ones(2, dtype='float64')
-    idxmap = np.indices((first_naxis1, first_naxis2), dtype='float64')
+    one = np.ones(2, dtype="float64")
+    idxmap = np.indices((first_naxis1, first_naxis2), dtype="float64")
     idxmap = idxmap.transpose() + one
 
     idxmap = idxmap.reshape(first_naxis2 * first_naxis1, 2)

--- a/drizzle/doblot.py
+++ b/drizzle/doblot.py
@@ -1,14 +1,24 @@
 """
 STScI Python compatable blot module
 """
+
 import numpy as np
 
 from drizzle import calc_pixmap
 from drizzle import cdrizzle
 
 
-def doblot(source, source_wcs, blot_wcs, exptime, coeffs=True,
-           interp='poly5', sinscl=1.0, stepsize=10, wcsmap=None):
+def doblot(
+    source,
+    source_wcs,
+    blot_wcs,
+    exptime,
+    coeffs=True,
+    interp="poly5",
+    sinscl=1.0,
+    stepsize=10,
+    wcsmap=None,
+):
     """
     Low level routine for performing the 'blot' operation.
 
@@ -74,7 +84,16 @@ def doblot(source, source_wcs, blot_wcs, exptime, coeffs=True,
     pixmap = calc_pixmap.calc_pixmap(blot_wcs, source_wcs)
     pix_ratio = source_wcs.pscale / blot_wcs.pscale
 
-    cdrizzle.tblot(source, pixmap, _outsci, scale=pix_ratio, kscale=1.0,
-                   interp=interp, exptime=exptime, misval=0.0, sinscl=sinscl)
+    cdrizzle.tblot(
+        source,
+        pixmap,
+        _outsci,
+        scale=pix_ratio,
+        kscale=1.0,
+        interp=interp,
+        exptime=exptime,
+        misval=0.0,
+        sinscl=sinscl,
+    )
 
     return _outsci

--- a/drizzle/dodrizzle.py
+++ b/drizzle/dodrizzle.py
@@ -1,6 +1,7 @@
 """
 STScI Python compatable drizzle module
 """
+
 import numpy as np
 
 from . import util
@@ -8,12 +9,27 @@ from . import calc_pixmap
 from . import cdrizzle
 
 
-def dodrizzle(insci, input_wcs, inwht,
-              output_wcs, outsci, outwht, outcon,
-              expin, in_units, wt_scl,
-              wcslin_pscale=1.0, uniqid=1,
-              xmin=0, xmax=0, ymin=0, ymax=0,
-              pixfrac=1.0, kernel='square', fillval="INDEF"):
+def dodrizzle(
+    insci,
+    input_wcs,
+    inwht,
+    output_wcs,
+    outsci,
+    outwht,
+    outcon,
+    expin,
+    in_units,
+    wt_scl,
+    wcslin_pscale=1.0,
+    uniqid=1,
+    xmin=0,
+    xmax=0,
+    ymin=0,
+    ymax=0,
+    pixfrac=1.0,
+    kernel="square",
+    fillval="INDEF",
+):
     """
     Low level routine for performing 'drizzle' operation.on one image.
 
@@ -134,18 +150,18 @@ def dodrizzle(insci, input_wcs, inwht,
     # Ensure that the fillval parameter gets properly interpreted
     # for use with tdriz
     if util.is_blank(fillval):
-        fillval = 'INDEF'
+        fillval = "INDEF"
     else:
         fillval = str(fillval)
 
-    if in_units == 'cps':
+    if in_units == "cps":
         expscale = 1.0
     else:
         expscale = expin
 
     # Add input weight image if it was not passed in
 
-    if (insci.dtype > np.float32):
+    if insci.dtype > np.float32:
         insci = insci.astype(np.float32)
 
     if inwht is None:
@@ -180,10 +196,24 @@ def dodrizzle(insci, input_wcs, inwht,
     # This call to 'cdriz.tdriz' uses the new C syntax
     #
     _vers, nmiss, nskip = cdrizzle.tdriz(
-        insci, inwht, pixmap, outsci, outwht, outcon,
-        uniqid=uniqid, xmin=xmin, xmax=xmax,
-        ymin=ymin, ymax=ymax, scale=pix_ratio, pixfrac=pixfrac,
-        kernel=kernel, in_units=in_units, expscale=expscale,
-        wtscale=wt_scl, fillstr=fillval)
+        insci,
+        inwht,
+        pixmap,
+        outsci,
+        outwht,
+        outcon,
+        uniqid=uniqid,
+        xmin=xmin,
+        xmax=xmax,
+        ymin=ymin,
+        ymax=ymax,
+        scale=pix_ratio,
+        pixfrac=pixfrac,
+        kernel=kernel,
+        in_units=in_units,
+        expscale=expscale,
+        wtscale=wt_scl,
+        fillstr=fillval,
+    )
 
     return _vers, nmiss, nskip

--- a/drizzle/drizzle.py
+++ b/drizzle/drizzle.py
@@ -2,6 +2,7 @@
 The `drizzle` module defines the `Drizzle` class, for combining input
 images into a single output image using the drizzle algorithm.
 """
+
 import os
 import os.path
 
@@ -18,9 +19,16 @@ class Drizzle(object):
     """
     Combine images using the drizzle algorithm
     """
-    def __init__(self, infile="", outwcs=None,
-                 wt_scl="exptime", pixfrac=1.0, kernel="square",
-                 fillval="INDEF"):
+
+    def __init__(
+        self,
+        infile="",
+        outwcs=None,
+        wt_scl="exptime",
+        pixfrac=1.0,
+        kernel="square",
+        fillval="INDEF",
+    ):
         """
         Create a new Drizzle output object and set the drizzle parameters.
 
@@ -107,8 +115,7 @@ class Drizzle(object):
                 self.wt_scl = util.get_keyword(handle, "DRIZWTSC", default=wt_scl)
                 self.kernel = util.get_keyword(handle, "DRIZKERN", default=kernel)
                 self.fillval = util.get_keyword(handle, "DRIZFVAL", default=fillval)
-                self.pixfrac = float(util.get_keyword(handle,
-                                     "DRIZPIXF", default=pixfrac))
+                self.pixfrac = float(util.get_keyword(handle, "DRIZPIXF", default=pixfrac))
 
                 out_units = util.get_keyword(handle, "DRIZOUUN", default="cps")
 
@@ -129,16 +136,15 @@ class Drizzle(object):
                     hdu = handle[self.ctxext]
                     self.outcon = hdu.data.copy().astype(np.int32)
                     if self.outcon.ndim == 2:
-                        self.outcon = np.reshape(self.outcon, (1,
-                                                 self.outcon.shape[0],
-                                                 self.outcon.shape[1]))
+                        self.outcon = np.reshape(
+                            self.outcon, (1, self.outcon.shape[0], self.outcon.shape[1])
+                        )
 
                     elif self.outcon.ndim == 3:
                         pass
 
                     else:
-                        msg = ("Drizzle context image has wrong dimensions: " +
-                               infile)
+                        msg = "Drizzle context image has wrong dimensions: " + infile
                         raise ValueError(msg)
 
                 except KeyError:
@@ -154,7 +160,7 @@ class Drizzle(object):
             raise ValueError("Either an existing file or wcs must be supplied to Drizzle")
 
         if util.is_blank(self.wt_scl):
-            self.wt_scl = ''
+            self.wt_scl = ""
         elif self.wt_scl != "exptime" and self.wt_scl != "expsq":
             raise ValueError("Illegal value for wt_scl: %s" % out_units)
 
@@ -166,19 +172,16 @@ class Drizzle(object):
         # Initialize images if not read from a file
         outwcs_naxis1, outwcs_naxis2 = self.outwcs.pixel_shape
         if self.outsci is None:
-            self.outsci = np.zeros(self.outwcs.pixel_shape[::-1],
-                                   dtype=np.float32)
+            self.outsci = np.zeros(self.outwcs.pixel_shape[::-1], dtype=np.float32)
 
         if self.outwht is None:
-            self.outwht = np.zeros(self.outwcs.pixel_shape[::-1],
-                                   dtype=np.float32)
+            self.outwht = np.zeros(self.outwcs.pixel_shape[::-1], dtype=np.float32)
         if self.outcon is None:
-            self.outcon = np.zeros((1, outwcs_naxis2, outwcs_naxis1),
-                                   dtype=np.int32)
+            self.outcon = np.zeros((1, outwcs_naxis2, outwcs_naxis1), dtype=np.int32)
 
-    def add_fits_file(self, infile, inweight="",
-                      xmin=0, xmax=0, ymin=0, ymax=0,
-                      unitkey="", expkey="", wt_scl=1.0):
+    def add_fits_file(
+        self, infile, inweight="", xmin=0, xmax=0, ymin=0, ymax=0, unitkey="", expkey="", wt_scl=1.0
+    ):
         """
         Combine a fits file with the output drizzled image.
 
@@ -272,13 +275,32 @@ class Drizzle(object):
         in_units = util.get_keyword(fileroot, unitkey, "cps")
         expin = util.get_keyword(fileroot, expkey, 1.0)
 
-        self.add_image(insci, inwcs, inwht=inwht,
-                       xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax,
-                       expin=expin, in_units=in_units, wt_scl=wt_scl)
+        self.add_image(
+            insci,
+            inwcs,
+            inwht=inwht,
+            xmin=xmin,
+            xmax=xmax,
+            ymin=ymin,
+            ymax=ymax,
+            expin=expin,
+            in_units=in_units,
+            wt_scl=wt_scl,
+        )
 
-    def add_image(self, insci, inwcs, inwht=None,
-                  xmin=0, xmax=0, ymin=0, ymax=0,
-                  expin=1.0, in_units="cps", wt_scl=1.0):
+    def add_image(
+        self,
+        insci,
+        inwcs,
+        inwht=None,
+        xmin=0,
+        xmax=0,
+        ymin=0,
+        ymax=0,
+        expin=1.0,
+        in_units="cps",
+        wt_scl=1.0,
+    ):
         """
         Combine an input image with the output drizzled image.
 
@@ -361,15 +383,29 @@ class Drizzle(object):
         self.increment_id()
         self.outexptime += expin
 
-        dodrizzle.dodrizzle(insci, inwcs, inwht, self.outwcs,
-                            self.outsci, self.outwht, self.outcon,
-                            expin, in_units, wt_scl,
-                            wcslin_pscale=inwcs.pscale, uniqid=self.uniqid,
-                            xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax,
-                            pixfrac=self.pixfrac, kernel=self.kernel,
-                            fillval=self.fillval)
+        dodrizzle.dodrizzle(
+            insci,
+            inwcs,
+            inwht,
+            self.outwcs,
+            self.outsci,
+            self.outwht,
+            self.outcon,
+            expin,
+            in_units,
+            wt_scl,
+            wcslin_pscale=inwcs.pscale,
+            uniqid=self.uniqid,
+            xmin=xmin,
+            xmax=xmax,
+            ymin=ymin,
+            ymax=ymax,
+            pixfrac=self.pixfrac,
+            kernel=self.kernel,
+            fillval=self.fillval,
+        )
 
-    def blot_fits_file(self, infile, interp='poly5', sinscl=1.0):
+    def blot_fits_file(self, infile, interp="poly5", sinscl=1.0):
         """
         Resample the output using another image's world coordinate system.
 
@@ -409,7 +445,7 @@ class Drizzle(object):
 
         self.blot_image(blotwcs, interp=interp, sinscl=sinscl)
 
-    def blot_image(self, blotwcs, interp='poly5', sinscl=1.0):
+    def blot_image(self, blotwcs, interp="poly5", sinscl=1.0):
         """
         Resample the output image using an input world coordinate system.
 
@@ -432,8 +468,9 @@ class Drizzle(object):
         """
 
         util.set_pscale(blotwcs)
-        self.outsci = doblot.doblot(self.outsci, self.outwcs, blotwcs,
-                                    1.0, interp=interp, sinscl=sinscl)
+        self.outsci = doblot.doblot(
+            self.outsci, self.outwcs, blotwcs, 1.0, interp=interp, sinscl=sinscl
+        )
 
         self.outwcs = blotwcs
 
@@ -499,40 +536,31 @@ class Drizzle(object):
         phdu = handle[0]
 
         # Write the class fields to the primary header
-        phdu.header['DRIZOUDA'] = \
-            (self.sciext, 'Drizzle, output data image')
-        phdu.header['DRIZOUWE'] = \
-            (self.whtext, 'Drizzle, output weighting image')
-        phdu.header['DRIZOUCO'] = \
-            (self.ctxext, 'Drizzle, output context image')
-        phdu.header['DRIZWTSC'] = \
-            (self.wt_scl, 'Drizzle, weighting factor for input image')
-        phdu.header['DRIZKERN'] = \
-            (self.kernel, 'Drizzle, form of weight distribution kernel')
-        phdu.header['DRIZPIXF'] = \
-            (self.pixfrac, 'Drizzle, linear size of drop')
-        phdu.header['DRIZFVAL'] = \
-            (self.fillval, 'Drizzle, fill value for zero weight output pix')
-        phdu.header['DRIZOUUN'] = \
-            (out_units, 'Drizzle, units of output image - counts or cps')
+        phdu.header["DRIZOUDA"] = (self.sciext, "Drizzle, output data image")
+        phdu.header["DRIZOUWE"] = (self.whtext, "Drizzle, output weighting image")
+        phdu.header["DRIZOUCO"] = (self.ctxext, "Drizzle, output context image")
+        phdu.header["DRIZWTSC"] = (self.wt_scl, "Drizzle, weighting factor for input image")
+        phdu.header["DRIZKERN"] = (self.kernel, "Drizzle, form of weight distribution kernel")
+        phdu.header["DRIZPIXF"] = (self.pixfrac, "Drizzle, linear size of drop")
+        phdu.header["DRIZFVAL"] = (self.fillval, "Drizzle, fill value for zero weight output pix")
+        phdu.header["DRIZOUUN"] = (out_units, "Drizzle, units of output image - counts or cps")
 
         # Update header keyword NDRIZIM to keep track of how many images have
         # been combined in this product so far
-        phdu.header['NDRIZIM'] = (self.uniqid, 'Drizzle, number of images')
+        phdu.header["NDRIZIM"] = (self.uniqid, "Drizzle, number of images")
 
         # Update header of output image with exptime used to scale the output data
         # if out_units is not counts, this will simply be a value of 1.0
         # the keyword 'exptime' will always contain the total exposure time
         # of all input image regardless of the output units
 
-        phdu.header['EXPTIME'] = \
-            (self.outexptime, 'Drizzle, total exposure time')
+        phdu.header["EXPTIME"] = (self.outexptime, "Drizzle, total exposure time")
 
         outexptime = 1.0
-        if out_units == 'counts':
+        if out_units == "counts":
             np.multiply(self.outsci, self.outexptime, self.outsci)
             outexptime = self.outexptime
-        phdu.header['DRIZEXPT'] = (outexptime, 'Drizzle, exposure time scaling factor')
+        phdu.header["DRIZEXPT"] = (outexptime, "Drizzle, exposure time scaling factor")
 
         # Copy the optional header to the primary header
 
@@ -546,22 +574,22 @@ class Drizzle(object):
 
         ehdu = fits.ImageHDU()
         ehdu.data = self.outsci
-        ehdu.header['EXTNAME'] = (self.sciext, 'Extension name')
-        ehdu.header['EXTVER'] = (1, 'Extension version')
+        ehdu.header["EXTNAME"] = (self.sciext, "Extension name")
+        ehdu.header["EXTVER"] = (1, "Extension version")
         ehdu.header.extend(extheader, unique=True)
         handle.append(ehdu)
 
         whdu = fits.ImageHDU()
         whdu.data = self.outwht
-        whdu.header['EXTNAME'] = (self.whtext, 'Extension name')
-        whdu.header['EXTVER'] = (1, 'Extension version')
+        whdu.header["EXTNAME"] = (self.whtext, "Extension name")
+        whdu.header["EXTVER"] = (1, "Extension version")
         whdu.header.extend(extheader, unique=True)
         handle.append(whdu)
 
         xhdu = fits.ImageHDU()
         xhdu.data = self.outcon
-        xhdu.header['EXTNAME'] = (self.ctxext, 'Extension name')
-        xhdu.header['EXTVER'] = (1, 'Extension version')
+        xhdu.header["EXTNAME"] = (self.ctxext, "Extension name")
+        xhdu.header["EXTVER"] = (1, "Extension version")
         xhdu.header.extend(extheader, unique=True)
         handle.append(xhdu)
 

--- a/drizzle/tests/test_cdrizzle.py
+++ b/drizzle/tests/test_cdrizzle.py
@@ -9,16 +9,14 @@ def test_cdrizzle():
     """
 
     size = 100
-    data = np.zeros((size,size), dtype='float32')
-    weights = np.ones((size,size), dtype='float32')
+    data = np.zeros((size, size), dtype="float32")
+    weights = np.ones((size, size), dtype="float32")
 
-    pixmap = np.indices((size,size), dtype='float64')
+    pixmap = np.indices((size, size), dtype="float64")
     pixmap = pixmap.transpose()
 
-    output_data = np.zeros((size,size), dtype='float32')
-    output_counts = np.zeros((size,size), dtype='float32')
-    output_context = np.zeros((size,size), dtype='int32')
+    output_data = np.zeros((size, size), dtype="float32")
+    output_counts = np.zeros((size, size), dtype="float32")
+    output_context = np.zeros((size, size), dtype="int32")
 
-    cdrizzle.test_cdrizzle(data, weights, pixmap,
-                           output_data, output_counts,
-                           output_context)
+    cdrizzle.test_cdrizzle(data, weights, pixmap, output_data, output_counts, output_context)

--- a/drizzle/tests/test_drizzle.py
+++ b/drizzle/tests/test_drizzle.py
@@ -9,7 +9,7 @@ from astropy.io import fits
 from drizzle import drizzle, cdrizzle
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
-DATA_DIR = os.path.join(TEST_DIR, 'data')
+DATA_DIR = os.path.join(TEST_DIR, "data")
 ok = False
 
 
@@ -53,8 +53,9 @@ def centroid_close(list_of_centroids, size, point):
     Find if any centroid is close to a point
     """
     for i in range(len(list_of_centroids) - 1, -1, -1):
-        if (abs(list_of_centroids[i][0] - point[0]) < int(size / 2) and
-                abs(list_of_centroids[i][1] - point[1]) < int(size / 2)):
+        if abs(list_of_centroids[i][0] - point[0]) < int(size / 2) and abs(
+            list_of_centroids[i][1] - point[1]
+        ) < int(size / 2):
             return 1
 
     return 0
@@ -110,7 +111,7 @@ def centroid_statistics(title, fname, image1, image2, amp, size):
     diff = []
     distances = centroid_distances(image1, image2, amp, size)
     indexes = (0, int(len(distances) / 2), len(distances) - 1)
-    fd = open(fname, 'w')
+    fd = open(fname, "w")
     fd.write("*** %s ***\n" % title)
 
     if len(distances) == 0:
@@ -121,38 +122,47 @@ def centroid_statistics(title, fname, image1, image2, amp, size):
         diff = [distances[0][0], distances[0][0], distances[0][0]]
 
         fd.write("1 match\n")
-        fd.write("distance = %f flux difference = %f\n" %
-                 (distances[0][0], distances[0][1]))
+        fd.write("distance = %f flux difference = %f\n" % (distances[0][0], distances[0][1]))
 
         for j in range(2, 4):
             ylo = int(distances[0][j][0]) - 1
             yhi = int(distances[0][j][0]) + 2
             xlo = int(distances[0][j][1]) - 1
             xhi = int(distances[0][j][1]) + 2
-            subimage = images[j][ylo:yhi,xlo:xhi]
-            fd.write("\n%s image centroid = (%f,%f) image flux = %f\n" %
-                     (im_type[j], distances[0][j][0], distances[0][j][1],
-                      distances[0][j][2]))
+            subimage = images[j][ylo:yhi, xlo:xhi]
+            fd.write(
+                "\n%s image centroid = (%f,%f) image flux = %f\n"
+                % (im_type[j], distances[0][j][0], distances[0][j][1], distances[0][j][2])
+            )
             fd.write(str(subimage) + "\n")
 
     else:
         fd.write("%d matches\n" % len(distances))
 
-        for k in range(0,3):
+        for k in range(0, 3):
             i = indexes[k]
             diff.append(distances[i][0])
-            fd.write("\n%s distance = %f flux difference = %f\n" %
-                     (stats[k],distances[i][0], distances[i][1]))
+            fd.write(
+                "\n%s distance = %f flux difference = %f\n"
+                % (stats[k], distances[i][0], distances[i][1])
+            )
 
             for j in range(2, 4):
                 ylo = int(distances[i][j][0]) - 1
                 yhi = int(distances[i][j][0]) + 2
                 xlo = int(distances[i][j][1]) - 1
                 xhi = int(distances[i][j][1]) + 2
-                subimage = images[j][ylo:yhi,xlo:xhi]
-                fd.write("\n%s %s image centroid = (%f,%f) image flux = %f\n" %
-                         (stats[k], im_type[j], distances[i][j][0],
-                          distances[i][j][1], distances[i][j][2]))
+                subimage = images[j][ylo:yhi, xlo:xhi]
+                fd.write(
+                    "\n%s %s image centroid = (%f,%f) image flux = %f\n"
+                    % (
+                        stats[k],
+                        im_type[j],
+                        distances[i][j][0],
+                        distances[i][j][1],
+                        distances[i][j][2],
+                    )
+                )
                 fd.write(str(subimage) + "\n")
 
     fd.close()
@@ -178,7 +188,7 @@ def make_grid_image(input_image, spacing, value):
     half_space = int(spacing / 2)
     for y in range(half_space, shape[0], spacing):
         for x in range(half_space, shape[1], spacing):
-            output_image[y,x] = value
+            output_image[y, x] = value
 
     return output_image
 
@@ -218,16 +228,16 @@ def test_square_with_point(tmpdir):
     """
     Test do_driz square kernel with point
     """
-    output = str(tmpdir.join('output_square_point.fits'))
-    output_difference = str(tmpdir.join('difference_square_point.txt'))
+    output = str(tmpdir.join("output_square_point.fits"))
+    output_difference = str(tmpdir.join("difference_square_point.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_square_point.fits")
 
     insci = read_image(input_file)
     inwcs = read_wcs(input_file)
     insci = make_point_image(insci, (500, 200), 100.0)
-    inwht = np.ones(insci.shape,dtype=insci.dtype)
+    inwht = np.ones(insci.shape, dtype=insci.dtype)
     output_wcs = read_wcs(output_template)
 
     driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="")
@@ -239,17 +249,17 @@ def test_square_with_point(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("square with point",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "square with point", output_difference, driz.outsci, template_data, 20.0, 8
+        )
 
         assert med_diff < 1.0e-6
         assert max_diff < 1.0e-5
 
 
 @pytest.mark.parametrize(
-    'kernel', ['square', 'point', 'turbo', 'gaussian', 'lanczos3'],
+    "kernel",
+    ["square", "point", "turbo", "gaussian", "lanczos3"],
 )
 def test_zero_input_weight(kernel):
     """
@@ -270,17 +280,23 @@ def test_zero_input_weight(kernel):
 
     # resample:
     cdrizzle.tdriz(
-        insci, inwht, pixmap,
-        outsci, outwht, outctx,
+        insci,
+        inwht,
+        pixmap,
+        outsci,
+        outwht,
+        outctx,
         uniqid=1,
-        xmin=0, xmax=400,
-        ymin=0, ymax=200,
+        xmin=0,
+        xmax=400,
+        ymin=0,
+        ymax=200,
         pixfrac=1,
         kernel=kernel,
-        in_units='cps',
+        in_units="cps",
         expscale=1,
         wtscale=1,
-        fillstr='INDEF',
+        fillstr="INDEF",
     )
 
     # check that no pixel with 0 weight has any counts:
@@ -291,17 +307,17 @@ def test_square_with_grid(tmpdir):
     """
     Test do_driz square kernel with grid
     """
-    output = str(tmpdir.join('output_square_grid.fits'))
-    output_difference = str(tmpdir.join('difference_square_grid.txt'))
+    output = str(tmpdir.join("output_square_grid.fits"))
+    output_difference = str(tmpdir.join("difference_square_grid.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_square_grid.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_square_grid.fits")
 
     insci = read_image(input_file)
     inwcs = read_wcs(input_file)
     insci = make_grid_image(insci, 64, 100.0)
 
-    inwht = np.ones(insci.shape,dtype=insci.dtype)
+    inwht = np.ones(insci.shape, dtype=insci.dtype)
     output_wcs = read_wcs(output_template)
 
     driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="")
@@ -313,10 +329,9 @@ def test_square_with_grid(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("square with grid",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "square with grid", output_difference, driz.outsci, template_data, 20.0, 8
+        )
         assert med_diff < 1.0e-6
         assert max_diff < 1.0e-5
 
@@ -325,19 +340,19 @@ def test_turbo_with_grid(tmpdir):
     """
     Test do_driz turbo kernel with grid
     """
-    output = str(tmpdir.join('output_turbo_grid.fits'))
-    output_difference = str(tmpdir.join('difference_turbo_grid.txt'))
+    output = str(tmpdir.join("output_turbo_grid.fits"))
+    output_difference = str(tmpdir.join("difference_turbo_grid.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_turbo_grid.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_turbo_grid.fits")
 
     insci = read_image(input_file)
     inwcs = read_wcs(input_file)
     insci = make_grid_image(insci, 64, 100.0)
-    inwht = np.ones(insci.shape,dtype=insci.dtype)
+    inwht = np.ones(insci.shape, dtype=insci.dtype)
     output_wcs = read_wcs(output_template)
 
-    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="", kernel='turbo')
+    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="", kernel="turbo")
     driz.add_image(insci, inwcs, inwht=inwht)
 
     if ok:
@@ -346,10 +361,9 @@ def test_turbo_with_grid(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("turbo with grid",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "turbo with grid", output_difference, driz.outsci, template_data, 20.0, 8
+        )
 
         assert med_diff < 1.0e-6
         assert max_diff < 1.0e-5
@@ -359,19 +373,19 @@ def test_gaussian_with_grid(tmpdir):
     """
     Test do_driz gaussian kernel with grid
     """
-    output = str(tmpdir.join('output_gaussian_grid.fits'))
-    output_difference = str(tmpdir.join('difference_gaussian_grid.txt'))
+    output = str(tmpdir.join("output_gaussian_grid.fits"))
+    output_difference = str(tmpdir.join("difference_gaussian_grid.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_gaussian_grid.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_gaussian_grid.fits")
 
     insci = read_image(input_file)
     inwcs = read_wcs(input_file)
     insci = make_grid_image(insci, 64, 100.0)
-    inwht = np.ones(insci.shape,dtype=insci.dtype)
+    inwht = np.ones(insci.shape, dtype=insci.dtype)
     output_wcs = read_wcs(output_template)
 
-    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="", kernel='gaussian')
+    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="", kernel="gaussian")
     driz.add_image(insci, inwcs, inwht=inwht)
 
     if ok:
@@ -380,10 +394,9 @@ def test_gaussian_with_grid(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("gaussian with grid",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "gaussian with grid", output_difference, driz.outsci, template_data, 20.0, 8
+        )
 
         assert med_diff < 1.0e-6
         assert max_diff < 2.0e-5
@@ -393,19 +406,19 @@ def test_lanczos_with_grid(tmpdir):
     """
     Test do_driz lanczos kernel with grid
     """
-    output = str(tmpdir.join('output_lanczos_grid.fits'))
-    output_difference = str(tmpdir.join('difference_lanczos_grid.txt'))
+    output = str(tmpdir.join("output_lanczos_grid.fits"))
+    output_difference = str(tmpdir.join("difference_lanczos_grid.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_lanczos_grid.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_lanczos_grid.fits")
 
     insci = read_image(input_file)
     inwcs = read_wcs(input_file)
     insci = make_grid_image(insci, 64, 100.0)
-    inwht = np.ones(insci.shape,dtype=insci.dtype)
+    inwht = np.ones(insci.shape, dtype=insci.dtype)
     output_wcs = read_wcs(output_template)
 
-    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="", kernel='lanczos3')
+    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="", kernel="lanczos3")
     driz.add_image(insci, inwcs, inwht=inwht)
 
     if ok:
@@ -414,10 +427,9 @@ def test_lanczos_with_grid(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("lanczos with grid",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "lanczos with grid", output_difference, driz.outsci, template_data, 20.0, 8
+        )
         assert med_diff < 1.0e-6
         assert max_diff < 1.0e-5
 
@@ -426,19 +438,19 @@ def test_tophat_with_grid(tmpdir):
     """
     Test do_driz tophat kernel with grid
     """
-    output = str(tmpdir.join('output_tophat_grid.fits'))
-    output_difference = str(tmpdir.join('difference_tophat_grid.txt'))
+    output = str(tmpdir.join("output_tophat_grid.fits"))
+    output_difference = str(tmpdir.join("difference_tophat_grid.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_tophat_grid.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_tophat_grid.fits")
 
     insci = read_image(input_file)
     inwcs = read_wcs(input_file)
     insci = make_grid_image(insci, 64, 100.0)
-    inwht = np.ones(insci.shape,dtype=insci.dtype)
+    inwht = np.ones(insci.shape, dtype=insci.dtype)
     output_wcs = read_wcs(output_template)
 
-    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="", kernel='tophat')
+    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="", kernel="tophat")
     driz.add_image(insci, inwcs, inwht=inwht)
 
     if ok:
@@ -447,10 +459,9 @@ def test_tophat_with_grid(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("tophat with grid",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "tophat with grid", output_difference, driz.outsci, template_data, 20.0, 8
+        )
         assert med_diff < 1.0e-6
         assert max_diff < 1.0e-5
 
@@ -459,19 +470,19 @@ def test_point_with_grid(tmpdir):
     """
     Test do_driz point kernel with grid
     """
-    output = str(tmpdir.join('output_point_grid.fits'))
-    output_difference = str(tmpdir.join('difference_point_grid.txt'))
+    output = str(tmpdir.join("output_point_grid.fits"))
+    output_difference = str(tmpdir.join("difference_point_grid.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_point_grid.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_point_grid.fits")
 
     insci = read_image(input_file)
     inwcs = read_wcs(input_file)
     insci = make_grid_image(insci, 64, 100.0)
-    inwht = np.ones(insci.shape,dtype=insci.dtype)
+    inwht = np.ones(insci.shape, dtype=insci.dtype)
     output_wcs = read_wcs(output_template)
 
-    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="", kernel='point')
+    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="", kernel="point")
     driz.add_image(insci, inwcs, inwht=inwht)
 
     if ok:
@@ -480,10 +491,9 @@ def test_point_with_grid(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("point with grid",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 8)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "point with grid", output_difference, driz.outsci, template_data, 20.0, 8
+        )
         assert med_diff < 1.0e-6
         assert max_diff < 1.0e-5
 
@@ -492,11 +502,11 @@ def test_blot_with_point(tmpdir):
     """
     Test do_blot with point image
     """
-    output = str(tmpdir.join('output_blot_point.fits'))
-    output_difference = str(tmpdir.join('difference_blot_point.txt'))
+    output = str(tmpdir.join("output_blot_point.fits"))
+    output_difference = str(tmpdir.join("difference_blot_point.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_blot_point.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_blot_point.fits")
 
     outsci = read_image(input_file)
     outwcs = read_wcs(input_file)
@@ -514,10 +524,9 @@ def test_blot_with_point(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("blot with point",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 16)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "blot with point", output_difference, driz.outsci, template_data, 20.0, 16
+        )
         assert med_diff < 1.0e-6
         assert max_diff < 1.0e-5
 
@@ -526,11 +535,11 @@ def test_blot_with_default(tmpdir):
     """
     Test do_blot with default grid image
     """
-    output = str(tmpdir.join('output_blot_default.fits'))
-    output_difference = str(tmpdir.join('difference_blot_default.txt'))
+    output = str(tmpdir.join("output_blot_default.fits"))
+    output_difference = str(tmpdir.join("difference_blot_default.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_blot_default.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_blot_default.fits")
 
     outsci = read_image(input_file)
     outsci = make_grid_image(outsci, 64, 100.0)
@@ -548,10 +557,9 @@ def test_blot_with_default(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("blot with defaults",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 16)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "blot with defaults", output_difference, driz.outsci, template_data, 20.0, 16
+        )
 
         assert med_diff < 1.0e-6
         assert max_diff < 1.0e-5
@@ -561,11 +569,11 @@ def test_blot_with_lan3(tmpdir):
     """
     Test do_blot with lan3 grid image
     """
-    output = str(tmpdir.join('output_blot_lan3.fits'))
-    output_difference = str(tmpdir.join('difference_blot_lan3.txt'))
+    output = str(tmpdir.join("output_blot_lan3.fits"))
+    output_difference = str(tmpdir.join("difference_blot_lan3.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_blot_lan3.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_blot_lan3.fits")
 
     outsci = read_image(input_file)
     outsci = make_grid_image(outsci, 64, 100.0)
@@ -583,10 +591,9 @@ def test_blot_with_lan3(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("blot with lan3",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 16)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "blot with lan3", output_difference, driz.outsci, template_data, 20.0, 16
+        )
         assert med_diff < 1.0e-6
         assert max_diff < 1.0e-5
 
@@ -595,11 +602,11 @@ def test_blot_with_lan5(tmpdir):
     """
     Test do_blot with lan5 grid image
     """
-    output = str(tmpdir.join('output_blot_lan5.fits'))
-    output_difference = str(tmpdir.join('difference_blot_lan5.txt'))
+    output = str(tmpdir.join("output_blot_lan5.fits"))
+    output_difference = str(tmpdir.join("difference_blot_lan5.txt"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_blot_lan5.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_blot_lan5.fits")
 
     outsci = read_image(input_file)
     outsci = make_grid_image(outsci, 64, 100.0)
@@ -617,10 +624,9 @@ def test_blot_with_lan5(tmpdir):
         driz.write(output)
         template_data = read_image(output_template)
 
-        min_diff, med_diff, max_diff = centroid_statistics("blot with lan5",
-                                                           output_difference,
-                                                           driz.outsci,
-                                                           template_data, 20.0, 16)
+        min_diff, med_diff, max_diff = centroid_statistics(
+            "blot with lan5", output_difference, driz.outsci, template_data, 20.0, 16
+        )
         assert med_diff < 1.0e-6
         assert max_diff < 1.0e-5
 
@@ -645,22 +651,22 @@ def test_context_planes():
 
 
 @pytest.mark.parametrize(
-    'kernel',
+    "kernel",
     [
-        'square',
-        'point',
-        'turbo',
+        "square",
+        "point",
+        "turbo",
         pytest.param(
-            'lanczos2',
-            marks=pytest.mark.xfail(reason='Not a flux-conserving kernel'),
+            "lanczos2",
+            marks=pytest.mark.xfail(reason="Not a flux-conserving kernel"),
         ),
         pytest.param(
-            'lanczos3',
-            marks=pytest.mark.xfail(reason='Not a flux-conserving kernel'),
+            "lanczos3",
+            marks=pytest.mark.xfail(reason="Not a flux-conserving kernel"),
         ),
         pytest.param(
-            'gaussian',
-            marks=pytest.mark.xfail(reason='Not a flux-conserving kernel'),
+            "gaussian",
+            marks=pytest.mark.xfail(reason="Not a flux-conserving kernel"),
         ),
     ],
 )
@@ -677,7 +683,9 @@ def test_flux_conservation_nondistorted(kernel):
     y0 = 68.0
     sig = fwhm / (2.0 * np.sqrt(2.0 * np.log(2.0 * fwhm)))
     sig2 = sig * sig
-    star = np.exp(-0.5 / sig2 * ((x.astype(np.float32) - x0)**2 + (y.astype(np.float32) - y0)**2))
+    star = np.exp(
+        -0.5 / sig2 * ((x.astype(np.float32) - x0) ** 2 + (y.astype(np.float32) - y0) ** 2)
+    )
     in_sci = (star / np.sum(star)).astype(np.float32)  # normalize to 1
     in_wht = np.ones(in_shape, dtype=np.float32)
 
@@ -719,23 +727,24 @@ def test_flux_conservation_nondistorted(kernel):
         rtol=0.0001,
     )
 
+
 @pytest.mark.parametrize(
-    'kernel',
+    "kernel",
     [
-        'square',
-        'point',
-        'turbo',
+        "square",
+        "point",
+        "turbo",
         pytest.param(
-            'lanczos2',
-            marks=pytest.mark.xfail(reason='Not a flux-conserving kernel'),
+            "lanczos2",
+            marks=pytest.mark.xfail(reason="Not a flux-conserving kernel"),
         ),
         pytest.param(
-            'lanczos3',
-            marks=pytest.mark.xfail(reason='Not a flux-conserving kernel'),
+            "lanczos3",
+            marks=pytest.mark.xfail(reason="Not a flux-conserving kernel"),
         ),
         pytest.param(
-            'gaussian',
-            marks=pytest.mark.xfail(reason='Not a flux-conserving kernel'),
+            "gaussian",
+            marks=pytest.mark.xfail(reason="Not a flux-conserving kernel"),
         ),
     ],
 )
@@ -752,7 +761,9 @@ def test_flux_conservation_distorted(kernel):
     y0 = 68.0
     sig = fwhm / (2.0 * np.sqrt(2.0 * np.log(2.0 * fwhm)))
     sig2 = sig * sig
-    star = np.exp(-0.5 / sig2 * ((x.astype(np.float32) - x0)**2 + (y.astype(np.float32) - y0)**2))
+    star = np.exp(
+        -0.5 / sig2 * ((x.astype(np.float32) - x0) ** 2 + (y.astype(np.float32) - y0) ** 2)
+    )
     in_sci = (star / np.sum(star)).astype(np.float32)  # normalize to 1
     in_wht = np.ones(in_shape, dtype=np.float32)
 

--- a/drizzle/tests/test_file_io.py
+++ b/drizzle/tests/test_file_io.py
@@ -9,7 +9,7 @@ from drizzle import drizzle
 from drizzle import util
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
-DATA_DIR = os.path.join(TEST_DIR, 'data')
+DATA_DIR = os.path.join(TEST_DIR, "data")
 
 
 def read_header(filename):
@@ -45,12 +45,13 @@ def read_wcs(filename):
 @pytest.fixture
 def run_drizzle_reference_square_points(tmpdir):
     """Create an empty drizzle image"""
-    output_file = str(tmpdir.join('output_null_run.fits'))
-    output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
+    output_file = str(tmpdir.join("output_null_run.fits"))
+    output_template = os.path.join(DATA_DIR, "reference_square_point.fits")
 
     output_wcs = read_wcs(output_template)
-    driz = drizzle.Drizzle(outwcs=output_wcs, wt_scl="expsq", pixfrac=0.5,
-                           kernel="turbo", fillval="NaN")
+    driz = drizzle.Drizzle(
+        outwcs=output_wcs, wt_scl="expsq", pixfrac=0.5, kernel="turbo", fillval="NaN"
+    )
     driz.write(output_file)
 
     return output_file
@@ -59,23 +60,22 @@ def run_drizzle_reference_square_points(tmpdir):
 def test_null_run(run_drizzle_reference_square_points):
     output_file = run_drizzle_reference_square_points
     with fits.open(output_file) as hdulist:
-
         assert hdulist.index_of("SCI") == 1
         assert hdulist.index_of("WHT") == 2
         assert hdulist.index_of("CTX") == 3
 
         pheader = hdulist["PRIMARY"].header
 
-    assert pheader['DRIZOUDA'] == 'SCI'
-    assert pheader['DRIZOUWE'] == 'WHT'
-    assert pheader['DRIZOUCO'] == 'CTX'
-    assert pheader['DRIZWTSC'] == 'expsq'
-    assert pheader['DRIZKERN'] == 'turbo'
-    assert pheader['DRIZPIXF'] == 0.5
-    assert pheader['DRIZFVAL'] == 'NaN'
-    assert pheader['DRIZOUUN'] == 'cps'
-    assert pheader['EXPTIME'] == 0.0
-    assert pheader['DRIZEXPT'] == 1.0
+    assert pheader["DRIZOUDA"] == "SCI"
+    assert pheader["DRIZOUWE"] == "WHT"
+    assert pheader["DRIZOUCO"] == "CTX"
+    assert pheader["DRIZWTSC"] == "expsq"
+    assert pheader["DRIZKERN"] == "turbo"
+    assert pheader["DRIZPIXF"] == 0.5
+    assert pheader["DRIZFVAL"] == "NaN"
+    assert pheader["DRIZOUUN"] == "cps"
+    assert pheader["EXPTIME"] == 0.0
+    assert pheader["DRIZEXPT"] == 1.0
 
 
 def test_file_init(run_drizzle_reference_square_points):
@@ -87,19 +87,19 @@ def test_file_init(run_drizzle_reference_square_points):
     driz = drizzle.Drizzle(infile=input_file)
 
     assert driz.outexptime == 1.0
-    assert driz.wt_scl == 'expsq'
-    assert driz.kernel == 'turbo'
+    assert driz.wt_scl == "expsq"
+    assert driz.kernel == "turbo"
     assert driz.pixfrac == 0.5
-    assert driz.fillval == 'NaN'
+    assert driz.fillval == "NaN"
 
 
 @pytest.fixture
 def add_header(tmpdir):
     """Add extra keywords read from the header"""
-    output_file = str(tmpdir.join('output_add_header.fits'))
+    output_file = str(tmpdir.join("output_add_header.fits"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits')
-    output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits")
+    output_template = os.path.join(DATA_DIR, "reference_square_point.fits")
 
     driz = drizzle.Drizzle(infile=output_template)
     image = read_image(input_file)
@@ -107,8 +107,8 @@ def add_header(tmpdir):
     driz.add_image(image, inwcs)
 
     header = fits.header.Header()
-    header['ONEVAL'] = (1.0, 'test value')
-    header['TWOVAL'] = (2.0, 'test value')
+    header["ONEVAL"] = (1.0, "test value")
+    header["TWOVAL"] = (2.0, "test value")
 
     driz.write(output_file, outheader=header)
 
@@ -118,9 +118,9 @@ def add_header(tmpdir):
 def test_add_header(add_header):
     output_file = add_header
     header = read_header(output_file)
-    assert header['ONEVAL'] == 1.0
-    assert header['TWOVAL'] == 2.0
-    assert header['DRIZKERN'] == 'square'
+    assert header["ONEVAL"] == 1.0
+    assert header["TWOVAL"] == 2.0
+    assert header["DRIZKERN"] == "square"
 
 
 def test_add_file(add_header, tmpdir):
@@ -128,10 +128,10 @@ def test_add_file(add_header, tmpdir):
     Add an image read from a file
     """
     test_file = add_header
-    output_file = str(tmpdir.join('output_add_file.fits'))
+    output_file = str(tmpdir.join("output_add_file.fits"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits[1]')
-    output_template = os.path.join(DATA_DIR, 'reference_square_point.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits[1]")
+    output_template = os.path.join(DATA_DIR, "reference_square_point.fits")
 
     driz = drizzle.Drizzle(infile=output_template)
     driz.add_fits_file(input_file)
@@ -148,11 +148,11 @@ def test_blot_file(tmpdir):
     """
     Blot an image read from a file
     """
-    output_file = str(tmpdir.join('output_blot_file.fits'))
-    test_file = str(tmpdir.join('output_blot_image.fits'))
+    output_file = str(tmpdir.join("output_blot_file.fits"))
+    test_file = str(tmpdir.join("output_blot_image.fits"))
 
-    input_file = os.path.join(DATA_DIR, 'j8bt06nyq_flt.fits[1]')
-    output_template = os.path.join(DATA_DIR, 'reference_blot_image.fits')
+    input_file = os.path.join(DATA_DIR, "j8bt06nyq_flt.fits[1]")
+    output_template = os.path.join(DATA_DIR, "reference_blot_image.fits")
 
     blotwcs = read_wcs(input_file)
 

--- a/drizzle/tests/test_overlap_calc.py
+++ b/drizzle/tests/test_overlap_calc.py
@@ -93,7 +93,8 @@ def test_poly_intersection_with_self():
 
 
 @pytest.mark.parametrize(
-    'shift', [(0.25, 0.1), (-0.25, -0.1), (-0.25, 0.1), (0.25, -0.1)],
+    "shift",
+    [(0.25, 0.1), (-0.25, -0.1), (-0.25, 0.1), (0.25, -0.1)],
 )
 def test_poly_intersection_shifted(shift):
     p = [(0, 0), (1, 0), (1, 1), (0, 1)]
@@ -115,7 +116,8 @@ def test_poly_intersection_shifted(shift):
 
 
 @pytest.mark.parametrize(
-    'shift', [(0, 70), (70, 0), (0, -70), (-70, 0)],
+    "shift",
+    [(0, 70), (70, 0), (0, -70), (-70, 0)],
 )
 def test_poly_intersection_shifted_large(shift):
     p = [(-0.5, -0.5), (99.5, -0.5), (99.5, 99.5), (-0.5, 99.5)]
@@ -149,7 +151,8 @@ def test_poly_intersection_rotated45():
 
 
 @pytest.mark.parametrize(
-    'axis', [0, 1],
+    "axis",
+    [0, 1],
 )
 def test_poly_intersection_flipped_axis(axis):
     p = [(0, 0), (1, 0), (1, 1), (0, 1)]
@@ -177,7 +180,7 @@ def test_poly_intersection_reflect_origin():
 
 
 @pytest.mark.parametrize(
-    'q,small',
+    "q,small",
     [
         ([(0.1, 0.1), (0.9, 0.1), (0.9, 0.9), (0.1, 0.9)], True),
         ([(0.0, 0.0), (1.0, 0.0), (1.0, 0.4), (0.0, 0.4)], True),
@@ -195,7 +198,7 @@ def test_poly_includes_the_other(q, small):
 
 
 @pytest.mark.parametrize(
-    'q',
+    "q",
     [
         [(0, 0), (1, 0), (0.5, 0.6)],
         [(0.1, 0), (0.9, 0), (0.5, 0.6)],

--- a/drizzle/tests/test_pixmap.py
+++ b/drizzle/tests/test_pixmap.py
@@ -8,7 +8,7 @@ from astropy.io import fits
 from drizzle import calc_pixmap
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
-DATA_DIR = os.path.join(TEST_DIR, 'data')
+DATA_DIR = os.path.join(TEST_DIR, "data")
 
 
 def test_map_rectangular():
@@ -18,24 +18,24 @@ def test_map_rectangular():
     naxis1 = 1000
     naxis2 = 10
 
-    pixmap = np.indices((naxis1, naxis2), dtype='float32')
+    pixmap = np.indices((naxis1, naxis2), dtype="float32")
     pixmap = pixmap.transpose()
 
-    assert_equal(pixmap[5,500], (500,5))
+    assert_equal(pixmap[5, 500], (500, 5))
 
 
 def test_map_to_self():
     """
     Map a pixel array to itself. Should return the same array.
     """
-    input_file = os.path.join(DATA_DIR, 'input1.fits')
+    input_file = os.path.join(DATA_DIR, "input1.fits")
     input_hdu = fits.open(input_file)
 
     input_wcs = wcs.WCS(input_hdu[1].header)
     naxis1, naxis2 = input_wcs.pixel_shape
     input_hdu.close()
 
-    ok_pixmap = np.indices((naxis1, naxis2), dtype='float32')
+    ok_pixmap = np.indices((naxis1, naxis2), dtype="float32")
     ok_pixmap = ok_pixmap.transpose()
 
     pixmap = calc_pixmap.calc_pixmap(input_wcs, input_wcs)
@@ -50,7 +50,7 @@ def test_translated_map():
     """
     Map a pixel array to  at translated array.
     """
-    first_file = os.path.join(DATA_DIR, 'input1.fits')
+    first_file = os.path.join(DATA_DIR, "input1.fits")
     first_hdu = fits.open(first_file)
     first_header = first_hdu[1].header
 
@@ -58,14 +58,14 @@ def test_translated_map():
     naxis1, naxis2 = first_wcs.pixel_shape
     first_hdu.close()
 
-    second_file = os.path.join(DATA_DIR, 'input3.fits')
+    second_file = os.path.join(DATA_DIR, "input3.fits")
     second_hdu = fits.open(second_file)
     second_header = second_hdu[1].header
 
     second_wcs = wcs.WCS(second_header)
     second_hdu.close()
 
-    ok_pixmap = np.indices((naxis1, naxis2), dtype='float32') - 2.0
+    ok_pixmap = np.indices((naxis1, naxis2), dtype="float32") - 2.0
     ok_pixmap = ok_pixmap.transpose()
 
     pixmap = calc_pixmap.calc_pixmap(first_wcs, second_wcs)

--- a/drizzle/util.py
+++ b/drizzle/util.py
@@ -46,7 +46,7 @@ def find_keyword_extn(fimg, keyword, value=None):
     return extnum
 
 
-def get_extn(fimg, extn=''):
+def get_extn(fimg, extn=""):
     """
     Returns the FITS extension corresponding to extension specified in
     filename. Defaults to returning the first extension with data or the
@@ -153,7 +153,7 @@ def is_blank(value):
     return value.strip() == ""
 
 
-def parse_extn(extn=''):
+def parse_extn(extn=""):
     """
     Parse a string representing a qualified fits extension name as in the
     output of parse_filename and return a tuple (str(extname), int(extver)),
@@ -179,12 +179,12 @@ def parse_extn(extn=''):
     A tuple of the extension name and value
     """
     if not extn:
-        return ('', 0)
+        return ("", 0)
 
     try:
-        lext = extn.split(',')
+        lext = extn.split(",")
     except Exception:
-        return ('', 1)
+        return ("", 1)
 
     if len(lext) == 1 and lext[0].isdigit():
         return ("", int(lext[0]))
@@ -211,14 +211,14 @@ def parse_filename(filename):
     A tuple with the filename root and extension
     """
     # Parse out any extension specified in filename
-    _indx = filename.find('[')
+    _indx = filename.find("[")
     if _indx > 0:
         # Read extension name provided
         _fname = filename[:_indx]
-        _extn = filename[_indx + 1:-1]
+        _extn = filename[_indx + 1 : -1]
     else:
         _fname = filename
-        _extn = ''
+        _extn = ""
 
     return _fname, _extn
 
@@ -252,5 +252,5 @@ def set_pscale(the_wcs):
             pc = 1
 
     pccd = np.array(cdelt * pc)
-    scales = np.sqrt((pccd ** 2).sum(axis=0, dtype=float))
+    scales = np.sqrt((pccd**2).sum(axis=0, dtype=float))
     the_wcs.pscale = scales[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ norecursedirs = [
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
 extend-select = [
     "F",
     "W",

--- a/setup.py
+++ b/setup.py
@@ -9,30 +9,32 @@ import numpy
 
 
 def get_extensions():
-    srcdir = os.path.join(os.path.dirname(__file__), 'src')
-    cdriz_sources = ['cdrizzleapi.c',
-                     'cdrizzleblot.c',
-                     'cdrizzlebox.c',
-                     'cdrizzlemap.c',
-                     'cdrizzleutil.c',
-                     os.path.join('tests', 'utest_cdrizzle.c')]
+    srcdir = os.path.join(os.path.dirname(__file__), "src")
+    cdriz_sources = [
+        "cdrizzleapi.c",
+        "cdrizzleblot.c",
+        "cdrizzlebox.c",
+        "cdrizzlemap.c",
+        "cdrizzleutil.c",
+        os.path.join("tests", "utest_cdrizzle.c"),
+    ]
     sources = [os.path.join(srcdir, x) for x in cdriz_sources]
 
     cfg = {
-        'include_dirs': [],
-        'libraries': [],
-        'define_macros': [],
+        "include_dirs": [],
+        "libraries": [],
+        "define_macros": [],
     }
-    cfg['include_dirs'].append(numpy.get_include())
-    cfg['include_dirs'].append(srcdir)
-    if sys.platform != 'win32':
-        cfg['libraries'].append('m')
-    if sys.platform == 'win32':
-        cfg['define_macros'].append(('WIN32', None))
-        cfg['define_macros'].append(('__STDC__', 1))
-        cfg['define_macros'].append(('_CRT_SECURE_NO_WARNINGS', None))
+    cfg["include_dirs"].append(numpy.get_include())
+    cfg["include_dirs"].append(srcdir)
+    if sys.platform != "win32":
+        cfg["libraries"].append("m")
+    if sys.platform == "win32":
+        cfg["define_macros"].append(("WIN32", None))
+        cfg["define_macros"].append(("__STDC__", 1))
+        cfg["define_macros"].append(("_CRT_SECURE_NO_WARNINGS", None))
 
-    return [Extension(str('drizzle.cdrizzle'), sources, **cfg)]
+    return [Extension(str("drizzle.cdrizzle"), sources, **cfg)]
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ changedir = {toxinidir}
 deps =
     ruff
 commands =
-    ruff . {posargs}
+    ruff check . {posargs}
 
 [testenv:check-security]
 description = run bandit to check security compliance


### PR DESCRIPTION
this includes:
- fix the `ruff` configuration in `pyproject.toml`:
  ```diff
    [tool.ruff]
    line-length = 100
  + 
  + [tool.ruff.lint]
  ```
- update usage of `ruff check` in `tox.ini` (`tox -e check-style`):
  ```diff
  - ruff .
  + ruff check .
  ```
- run `ruff check --fix .`
- run `ruff format .`