### PR TITLE
Fix identical polygon test accuracy for unit tests

### DIFF
--- a/drizzle/tests/test_overlap_calc.py
+++ b/drizzle/tests/test_overlap_calc.py
@@ -9,7 +9,7 @@ from drizzle.cdrizzle import clip_polygon, invert_pixmap
 SQ2 = 1.0 / sqrt(2.0)
 
 
-def _is_poly_eq(p1, p2, rtol=0, atol=1e-12):
+def _is_poly_eq(p1, p2, rtol=0, atol=4e-12):
     if len(p1) != len(p2):
         return False
 


### PR DESCRIPTION
Relaxes the accuracy of identical polygon testing as `test_intersection_case01` seems to fail with Python 3.12 on Mac OSX.