### PR TITLE
[SCSB-155] build with Numpy 2.0 release candidate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ docs = [
 requires = [
     "setuptools>=61.2",
     "setuptools_scm[toml]>=3.4",
-    "numpy>=1.25",
+    "numpy>=2.0.0rc2",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
resolves [SCSB-155](https://jira.stsci.edu/browse/SCSB-155)

Numpy 2.0 is scheduled for release on June 19th. Due to the C ABI updates, Python projects that build C extensions are required to build against Numpy 2.0 in order to use Numpy 2.0 in runtime.
This is backwards-compatible with Numpy versions in runtime as far back as `1.26`

this PR pins `numpy>=2.0.0rc2` in `build-system.requires`
> [!NOTE]
> this PR was generated automatically by ``batchpr`` :robot: