### PR TITLE
Fix return type of PyInit_cdrizzle

### DIFF
--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -614,7 +614,7 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-PyMODINIT_FUNC *PyInit_cdrizzle(void)
+PyMODINIT_FUNC PyInit_cdrizzle(void)
 {
     PyObject *m;
     m = PyModule_Create(&moduledef);


### PR DESCRIPTION
The return type of the init function is `PyMODINIT_FUNC`, not `PyMODINIT_FUNC *`.

This was found by an error raised when built with gcc-14, see [Debian#1075414](https://bugs.debian.org/1075414).