### PR TITLE
allow `context` to be `None`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@
 Release Notes
 =============
 
-1.15.2 (2025-06-17)
+1.15.3 (unreleased)
+===================
+
+- allow ``context`` to be ``None`` in ``tdriz`` [#151]
+
+1.15.2 (2024-06-17)
 ===================
 
 - build wheels with Numpy 2.0 release candidate [#149]

--- a/drizzle/tests/test_drizzle.py
+++ b/drizzle/tests/test_drizzle.py
@@ -796,3 +796,39 @@ def test_flux_conservation_distorted(kernel):
         atol=0.0,
         rtol=0.0001,
     )
+
+
+def test_no_context_array():
+    """
+    Test that providing None for "outctx" is supported.
+    """
+    # initialize input:
+    insci = np.ones((200, 400), dtype=np.float32)
+    inwht = np.ones((200, 400), dtype=np.float32)
+    inwht[:, 150:155] = 0
+
+    # initialize output:
+    outsci = np.zeros((210, 410), dtype=np.float32)
+    outwht = np.zeros((210, 410), dtype=np.float32)
+    outctx = None
+
+    # define coordinate mapping:
+    pixmap = np.moveaxis(np.mgrid[1:201, 1:401][::-1], 0, -1)
+
+    # resample:
+    cdrizzle.tdriz(
+        insci, inwht, pixmap,
+        outsci, outwht, outctx,
+        uniqid=1,
+        xmin=0, xmax=400,
+        ymin=0, ymax=200,
+        pixfrac=1,
+        kernel='square',
+        in_units='cps',
+        expscale=1,
+        wtscale=1,
+        fillstr='INDEF',
+    )
+
+    # check that no pixel with 0 weight has any counts:
+    assert np.sum(np.abs(outsci[(outwht == 0)])) == 0.0

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -130,11 +130,13 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords)
     goto _exit;
   }
 
-  con = (PyArrayObject *)PyArray_ContiguousFromAny(ocon, NPY_INT32, 2, 2);
-  if (!con) {
-    driz_error_set_message(&error, "Invalid context array");
-    goto _exit;
-  }
+  if (ocon != Py_None) {
+    con = (PyArrayObject *)PyArray_ContiguousFromAny(ocon, NPY_INT32, 2, 2);
+    if (!con) {
+      driz_error_set_message(&error, "Invalid context array");
+      goto _exit;
+    }
+  };
 
   /* Convert t`he fill value string */
 


### PR DESCRIPTION
This PR allows `context` to be `None` for `tdriz` (to prevent the need for a context array).

One place where this would be useful is within the jwst and romancal pipelines where drizzle is used to generate intermediate products for outlier detection. These operations can involve large arrays and using `context=None` (and not generating a large context array) can result in memory savings.