### PR TITLE
allow python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,30 +31,4 @@ jobs:
         - linux: py312-xdist-cov
           coverage: codecov
 
-        #- linux: py312-xdist-devdeps
-
-  # When py312-xdist-devdeps works again, we can remove this.
-  # When, you ask? Well, maybe after numpy 2.0 is released, maybe.
-  dev_deps_tests:
-    name: py312-devdeps
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.12'
-    - name: Install and build
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy>=0.0.dev0 --pre --upgrade
-        python -m pip install --extra-index-url https://pypi.anaconda.org/liberfa/simple pyerfa>=0.0.dev0 --pre --upgrade
-        python -m pip install --extra-index-url https://pypi.anaconda.org/astropy/simple astropy>=0.0.dev0 --pre --upgrade
-        python -m pip install --no-build-isolation -v -e .[test]
-    - name: Test with dev deps
-      run: |
-        pip freeze
-        pytest -v
+        - linux: py312-xdist-devdeps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
 
         - linux: py310-xdist
         - linux: py311-xdist
+        - linux: py313-xdist
         - macos: py312-xdist
         - windows: py312-xdist
         - linux: py312-xdist-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "drizzle"
 description = "A package for combining dithered images into a single image"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10"
 authors = [
     { name = "STScI", email = "help@stsci.edu" },
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 env_list =
     check-{style,security}
-    py{39,310,311,312,313}{,-xdist}{,-devdeps,-cov}
+    py{310,311,312,313}{,-xdist}{,-devdeps,-cov}
 
 # tox environments are constructed with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 env_list =
     check-{style,security}
-    py{39,310,311,312}{,-xdist}{,-devdeps,-cov}
+    py{39,310,311,312,313}{,-xdist}{,-devdeps,-cov}
 
 # tox environments are constructed with so-called 'factors' (or terms)
 # separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:


### PR DESCRIPTION
This PR:
- adds python 3.13 testing to the CI: https://github.com/spacetelescope/drizzle/actions/runs/10473588949/job/29005811343?pr=156
- allows python 3.13 in pyproject.toml
- re-enables to previously disabled tox devdeps test https://github.com/spacetelescope/drizzle/actions/runs/10473588949/job/29005812771?pr=156

I added the devdeps change only because I saw the comment:
https://github.com/spacetelescope/drizzle/blob/f8ea30dc5b1eda828aa1e4191c9d9205f01551ae/.github/workflows/ci.yml#L35-L36
Since numpy 2.0 is out I figured I'd see if it works again (which it did). Let me know if it's preferable to have this change in a different PR.