### PR TITLE
add codecov token to uploader step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,5 @@ jobs:
           coverage: codecov
 
         - linux: py312-xdist-devdeps
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
this should fix the codecov upload not working for `main` (it works without a token on PRs)