### PR TITLE
Add support for co-adding with squared weights

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ source = drizzle
 
 omit =
     drizzle/__init__*
+    drizzle/util.py
     drizzle/**/conftest.py
     drizzle/**/setup*
     drizzle/**/tests/*

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,14 @@ Release Notes
 =============
 
 
+2.2.0 (unreleased)
+==================
+
+- Added support for resampling and co-adding images using squared weights.
+  This can be helpful when resampling variance arrays for the purpose of
+  performing propagation of uncertainties. [#163]
+
+
 2.1.1 (2025-08-14)
 ==================
 
@@ -14,19 +22,15 @@ Release Notes
 - Fixed a numerical instability in the new and old "boxer" algorithm in #175
   (withdrawn release 2.1.0). [#191]
 
+- Fixed a bug in polygon intersection algorithm that could result in
+  incorrect output when the input polygons have nearly collinear edges. [#194]
+
 
 2.1.0 (2025-02-20; withdrawn)
 =============================
 
 - Restored faster "boxer" overlap for square kernel, improving resample speed;
   optimized and simplified related code. [#175]
-
-
-2.1.1 (unreleased)
-==================
-
-- Fixed a bug in polygon intersection algorithm that could result in
-  incorrect output when the input polygons have nearly collinear edges. [#194]
 
 
 2.0.2 (unreleased)

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -450,7 +450,12 @@ class Drizzle:
             self._out_img = out_img
 
     def _alloc_output_arrays2_init(self, out_img2=None):
-        assert self._out_img2 is None
+        if hasattr(self, "_out_img2") and self._out_img2 is not None:
+            raise AssertionError(
+                "It is expected that _alloc_output_arrays2_init is called "
+                "before Drizzle._out_img2 is set."
+            )
+
         if out_img2 is None:
             return
 

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -659,7 +659,7 @@ class Drizzle:
             else:
                 shapes2 = set()
                 ninputs2 = len(data2)
-                data2 = [d for d in data2]
+                data2 = list(data2)
                 for k, d in enumerate(data2):
                     if d is None or d.size == 0:
                         data2[k] = None

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -198,18 +198,18 @@ class Drizzle:
             ``fillval`` value.
 
         fillval2: float, None, str, optional
-            Same as ``filvall`` but applies to ``out_img2``.
+            Same as ``fillval`` but applies to ``out_img2``.
 
         out_img : 2D array of float32, None, optional
             A 2D numpy array containing the output image produced by
             drizzling. On the first call the array values should be set to zero.
-            Subsequent calls it will hold the intermediate results.
+            On subsequent calls it will hold the intermediate results.
 
         out_img2 : 2D array of float32, list of 2D arrays of float32, None, optional
             A 2D numpy array containing the output image produced by
             drizzling *with squared weights*. This is useful when performing
             standard error propagation using variance arrays. On the first call
-            the array values should be set to zero. Subsequent calls it will
+            the array values should be set to zero. On subsequent calls it will
             hold the intermediate results.
 
             Multiple output arrays (of the same shape as that of ``out_img``)
@@ -318,7 +318,7 @@ class Drizzle:
 
         if out_img2 is not None:
             if isinstance(out_img2, np.ndarray):
-                out_img2 = np.asarray(out_img, dtype=np.float32)
+                out_img2 = np.asarray(out_img2, dtype=np.float32)
                 shapes.add(out_img2.shape)
             else:
                 out_img2 = [
@@ -671,7 +671,8 @@ class Drizzle:
                     else:
                         shapes2.add(d.shape)
 
-                if len(shapes2) > 1 and shapes2.pop() != data.shape:
+                if ((len(shapes2) == 1 and shapes2.pop() != data.shape) or
+                        len(shapes2) > 1):
                     raise ValueError(
                         "'data2' shape(s) is not consistent with 'data' shape."
                     )

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -1565,6 +1565,7 @@ def test_drizzle_weights_squared_pscale(kernel_fc, pscale, weights):
         atol=0.0
     )
 
+
 def test_drizzle_weights_squared_bad_inputs():
     n = 21
     in_shape = (n, n)

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -1584,24 +1584,17 @@ def test_drizzle_weights_squared_bad_inputs():
         "Mismatch between the number of 'out_img2' images"
     )
 
-    # 5 - test same number of data2 is used each time:
+    # 5 - test mismatch between output data image and output variance image:
     out_img2 = np.zeros(tuple(s + 1 for s in out_shape), dtype=np.float32)
-    driz = resample.Drizzle(
-        kernel=kernel,
-        out_img=out_img,
-        out_img2=out_img2,
-    )
 
     with pytest.raises(ValueError) as err_info:
-        driz.add_image(
-            data=in_sci2,
-            exptime=1.0,
-            pixmap=pixmap,
-            weight_map=in_wht2,
-            data2=None,
+        driz = resample.Drizzle(
+            kernel=kernel,
+            out_img=out_img,
+            out_img2=out_img2,
         )
     assert str(err_info.value).startswith(
-        "Mismatch between the number of 'out_img2' images"
+        "Inconsistent data shapes specified:"
     )
 
 

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -1973,7 +1973,6 @@ def test_drizzle_var_identical_to_nonvar(kernel_fc, pscale_ratio):
             )
 
     v = np.abs(driz1.out_img - driz2.out_img)
-    print(kernel, pscale_ratio, np.nanmax(v), np.nanmin(v), np.nanmean(v))
 
     assert np.allclose(
         driz1.out_img,

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -1362,7 +1362,7 @@ def test_resample_edge_collinear():
     ],
 )
 def test_drizzle_weights_squared(kernel, fc):
-    n = 200
+    n = 17
     in_shape = (n, n)
 
     # input coordinate grid:
@@ -1420,6 +1420,7 @@ def test_drizzle_weights_squared(kernel, fc):
             weight_map=in_wht2,
             data2=in_sci2_sq,
         )
+
         assert isinstance(driz.out_img2, list)
         assert len(driz.out_img2) == 1
 
@@ -1468,7 +1469,7 @@ def test_drizzle_weights_squared(kernel, fc):
 
 
 def test_drizzle_weights_squared_bad_inputs():
-    n = 200
+    n = 21
     in_shape = (n, n)
     kernel = "square"
 
@@ -1605,7 +1606,7 @@ def test_drizzle_weights_squared_bad_inputs():
 
 
 def test_drizzle_weights_squared_array_shape_mismatch():
-    n = 200
+    n = 20
     in_shape = (n, n)
     in_shape1 = (n + 1, n + 1)
     kernel = "square"
@@ -1650,6 +1651,22 @@ def test_drizzle_weights_squared_array_shape_mismatch():
         )
     assert str(err_info.value).startswith(
         "'data2' shape(s) is not consistent with 'data' shape."
+    )
+
+    driz = resample.Drizzle(
+        kernel=kernel,
+        out_img2=out_img2,
+    )
+    with pytest.raises(ValueError) as err_info:
+        driz.add_image(
+            data=in_sci1,
+            exptime=1.0,
+            pixmap=pixmap,
+            weight_map=in_wht2,
+            data2=in_sci2_sq,
+        )
+    assert str(err_info.value).startswith(
+        "'data2' shape is not consistent with 'data' shape."
     )
 
     with pytest.raises(ValueError) as err_info:

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -1494,7 +1494,7 @@ def test_drizzle_weights_squared_pscale(kernel_fc, pscale, weights):
     kernel, fc = kernel_fc
 
     # pixel values in input data:
-    dataval = [1, 7]
+    dataval = [1.0, 7.0]
 
     # pixel values in input variance:
     varval = [0.5, 50]
@@ -1508,10 +1508,11 @@ def test_drizzle_weights_squared_pscale(kernel_fc, pscale, weights):
     var = [np.zeros(shape, dtype=np.float32) for _ in range(2)]
 
     xc = yc = n // 2
+    sl = np.s_[yc - 4: yc + 5, xc - 4: xc + 5]
     for k in range(2):
-        data[k][xc - 4: xc + 5, yc - 4: yc + 5] = dataval[k]
-        weight[k][xc - 4: xc + 5, yc - 4: yc + 5] = weights[k]
-        var[k][xc - 4: xc + 5, yc - 4: yc + 5] = varval[k]
+        data[k][sl] = dataval[k]
+        weight[k][sl] = weights[k]
+        var[k][sl] = varval[k]
 
     out_shape = (int(pixmap[..., 1].max()) + 1, int(pixmap[..., 0].max()) + 1)
 

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -1972,8 +1972,6 @@ def test_drizzle_var_identical_to_nonvar(kernel_fc, pscale_ratio):
                 ymax=output_wcs.array_shape[1] - 10,
             )
 
-    v = np.abs(driz1.out_img - driz2.out_img)
-
     assert np.allclose(
         driz1.out_img,
         driz2.out_img,

--- a/drizzle/tests/test_utils.py
+++ b/drizzle/tests/test_utils.py
@@ -5,7 +5,6 @@ import pytest
 from numpy.testing import assert_almost_equal, assert_equal
 
 from astropy.wcs import FITSFixedWarning
-
 from drizzle.tests.helpers import wcs_from_file
 from drizzle.utils import (
     _estimate_pixel_scale,

--- a/drizzle/tests/test_utils.py
+++ b/drizzle/tests/test_utils.py
@@ -1,6 +1,10 @@
+import warnings
+
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_equal
+
+from astropy.wcs import FITSFixedWarning
 
 from drizzle.tests.helpers import wcs_from_file
 from drizzle.utils import (
@@ -166,7 +170,9 @@ def test_estimate_pixel_scale_ratio():
 
 def test_estimate_pixel_scale_no_refpix():
     # create a WCS without higher order (polynomial) distortions:
-    w = wcs_from_file("j8bt06nyq_sip_flt.fits", ext=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=FITSFixedWarning)
+        w = wcs_from_file("j8bt06nyq_sip_flt.fits", ext=1)
     w.sip = None
     w.det2im1 = None
     w.det2im2 = None

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -59,8 +59,6 @@ process_array_list(PyObject *list, integer_t *nx, integer_t *ny,
     PyArrayObject *arr = NULL;
     int i, at_least_one;
 
-    // *nx = -1;
-    // *ny = -1;
     *arrays = NULL;
     *nmax = 0;
     if (n_none) {
@@ -127,10 +125,11 @@ process_array_list(PyObject *list, integer_t *nx, integer_t *ny,
                 if (n_none) {
                     (*n_none)++;
                 }
-                arr = NULL;
+                arr_list[i] = NULL;
                 Py_XDECREF(list_elem);
                 continue;
             } else {
+                *n_none = 1;
                 driz_error_set(
                     error, PyExc_ValueError,
                     "Element %d of '%s' list is None which is not allowed.", i,

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -48,16 +48,128 @@ scale_image(PyArrayObject *image, double scale_factor) {
  * Top level function for drizzling, interfaces with python code
  */
 
+static int
+process_array_list(PyObject *list, integer_t *nx, integer_t *ny,
+                   const char *name, PyArrayObject ***arrays, int *narr,
+                   struct driz_error_t *error) {
+    npy_intp *ndim;
+    int inx, iny;
+    PyObject *list_elem = NULL;
+    PyArrayObject **arr_list = NULL;
+    PyArrayObject *arr = NULL;
+    int i, nmax;
+
+    *nx = 0;
+    *ny = 0;
+    *arrays = NULL;
+    *narr = 0;
+
+    if (list == NULL || list == Py_None) {
+        driz_error_set(error, PyExc_ValueError,
+                       "Array list '%s' is None or NULL.", name);
+        return 1;
+    }
+
+    if (PyArray_CheckExact(list)) {
+        if (!(arr_list = (PyArrayObject **)malloc(sizeof(PyArrayObject *)))) {
+            driz_error_set(error, PyExc_MemoryError,
+                           "Memory allocation failed.");
+            return 1;
+        }
+        arr = (PyArrayObject *)PyArray_ContiguousFromAny(list, NPY_FLOAT, 2, 2);
+        if (!arr) {
+            driz_error_set(error, PyExc_ValueError, "Invalid '%s' array.",
+                           name);
+            return 1;
+        }
+        *arr_list = arr;
+        *narr = 1;
+        ndim = PyArray_DIMS(arr);
+        *nx = (int)ndim[1];
+        *ny = (int)ndim[0];
+        *arrays = arr_list;
+        return 0;
+
+    } else if (!PyList_Check(list) && !PyTuple_Check(list)) {
+        driz_error_set(
+            error, PyExc_TypeError,
+            "Argument '%s' is not a list or a tuple of numpy.ndarray.", name);
+    }
+
+    if (!(nmax = PySequence_Size(list))) {
+        return 0;
+    }
+
+    arr_list = (PyArrayObject **)calloc(nmax, sizeof(PyArrayObject *));
+    if (!arr_list) {
+        driz_error_set(error, PyExc_MemoryError, "Memory allocation failed.");
+        return 1;
+    }
+
+    for (i = 0; i < nmax; ++i) {
+        if (!(list_elem = PySequence_GetItem(list, 0))) {
+            driz_error_set(error, PyExc_RuntimeError,
+                           "Error retrieving array from the '%s' list.", name);
+            goto _exit_on_err;
+        }
+
+        arr = (PyArrayObject *)PyArray_ContiguousFromAny(list_elem, NPY_FLOAT,
+                                                         2, 2);
+        Py_XDECREF(list_elem);
+        list_elem = NULL;
+
+        if (!arr) {
+            driz_error_set(error, PyExc_ValueError, "Invalid '%s' array.",
+                           name);
+            goto _exit_on_err;
+        }
+        arr_list[i] = arr;
+
+        if (i) {
+            ndim = PyArray_DIMS(arr);
+            inx = (int)ndim[1];
+            iny = (int)ndim[0];
+            if ((*nx != inx) || (*ny != iny)) {
+                driz_error_set(
+                    error, PyExc_ValueError,
+                    "Inconsistent image shape in the '%s' image list.", name);
+                goto _exit_on_err;
+            }
+        } else {
+            ndim = PyArray_DIMS(arr);
+            *nx = (int)ndim[1];
+            *ny = (int)ndim[0];
+        }
+    }
+    *arrays = arr_list;
+    *narr = nmax;
+
+    return 0;
+
+_exit_on_err:
+    Py_XDECREF(list_elem);
+    if (arr_list) {
+        for (i = 0; i < nmax; ++i) {
+            Py_XDECREF(arr_list[i]);
+        }
+        free(arr_list);
+    }
+}
+
 static PyObject *
 tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
-    const char *kwlist[] = {"input",   "weights", "pixmap",   "output",
-                            "counts",  "context", "uniqid",   "xmin",
-                            "xmax",    "ymin",    "ymax",     "scale",
-                            "pixfrac", "kernel",  "in_units", "expscale",
-                            "wtscale", "fillstr", NULL};
+    const char *kwlist[] = {
+        "input",   "weights", "pixmap",   "output", "counts",   "context",
+        "input2",  "output2", "uniqid",   "xmin",   "xmax",     "ymin",
+        "ymax",    "scale",   "pixfrac",  "kernel", "in_units", "expscale",
+        "wtscale", "fillstr", "fillstr2", NULL};
 
     /* Arguments in the order they appear */
     PyObject *oimg, *owei, *pixmap, *oout, *owht, *ocon;
+    PyObject *oimg2 = NULL, *oout2 = NULL;
+    int i;
+    int nsq_args, nsq_arr = 0, nsq_arr_out = 0;
+
     integer_t uniqid = 1;
     integer_t xmin = 0;
     integer_t xmax = 0;
@@ -70,20 +182,28 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
     float expin = 1.0;
     float wtscl = 1.0;
     char *fillstr = "INDEF";
+    char *fillstr2 = "INDEF";
 
     /* Derived values */
 
     PyArrayObject *img = NULL, *wei = NULL, *out = NULL, *wht = NULL,
                   *con = NULL, *map = NULL;
+
+    PyArrayObject **img2_list = NULL, **out2_list = NULL;
+
     enum e_kernel_t kernel;
     enum e_unit_t inun;
     char *fillstr_end;
-    bool_t do_fill;
-    float fill_value;
+    bool_t do_fill, do_fill2;
+    float fill_value, fill_value2;
     float inv_exposure_time;
     struct driz_error_t error;
     struct driz_param_t p;
-    integer_t isize[2], psize[2], wsize[2];
+    integer_t size[2];
+    integer_t nx, ny;   /* image dimensions */
+    integer_t inx, iny; /* input image dimensions */
+    integer_t onx, ony; /* output image dimensions */
+    npy_intp *ndim;
     char warn_msg[128];
 
     driz_log_handle = driz_log_init(driz_log_handle);
@@ -91,11 +211,12 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
     driz_error_init(&error);
 
     if (!PyArg_ParseTupleAndKeywords(
-            args, keywords, "OOOOOO|iiiiiddssffs:tdriz", (char **)kwlist, &oimg,
-            &owei, &pixmap, &oout, &owht, &ocon,     /* OOOOOO */
+            args, keywords, "OOOOOO|OOiiiiiddssffss:tdriz", (char **)kwlist,
+            &oimg, &owei, &pixmap, &oout, &owht, &ocon, &oimg2,
+            &oout2,                                  /* OOOOOOOO */
             &uniqid, &xmin, &xmax, &ymin, &ymax,     /* iiiii */
             &scale, &pfract, &kernel_str, &inun_str, /* ddss */
-            &expin, &wtscl, &fillstr)                /* ffs */
+            &expin, &wtscl, &fillstr, &fillstr2)     /* ffss */
     ) {
         return NULL;
     }
@@ -142,7 +263,6 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
     }
 
     /* Convert the fill value string */
-
     if (fillstr == NULL || *fillstr == 0 || strncmp(fillstr, "INDEF", 6) == 0 ||
         strncmp(fillstr, "indef", 6) == 0) {
         do_fill = 0;
@@ -166,11 +286,147 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
 #endif
     }
 
-    /* Set the area to be processed */
+    if (fillstr2 == NULL || *fillstr2 == 0 ||
+        strncmp(fillstr2, "INDEF", 6) == 0 ||
+        strncmp(fillstr2, "indef", 6) == 0) {
+        do_fill2 = 0;
+        fill_value2 = 0.0;
 
-    get_dimensions(img, isize);
-    if (xmax == 0 || xmax >= isize[0]) xmax = isize[0] - 1;
-    if (ymax == 0 || ymax >= isize[1]) ymax = isize[1] - 1;
+    } else if (strncmp(fillstr2, "NaN", 4) == 0 ||
+               strncmp(fillstr2, "nan", 4) == 0) {
+        do_fill2 = 1;
+        fill_value2 = NPY_NANF;
+
+    } else {
+        do_fill2 = 1;
+#ifdef _WIN32
+        fill_value2 = atof(fillstr2);
+#else
+        fill_value2 = strtof(fillstr2, &fillstr_end);
+        if (fillstr2 == fillstr_end || *fillstr_end != '\0') {
+            driz_error_set_message(&error, "Illegal fill value");
+            goto _exit;
+        }
+#endif
+    }
+
+    /* Check input array dimensions */
+    ndim = PyArray_DIMS(img);
+    inx = ndim[1];
+    iny = ndim[0];
+
+    ndim = PyArray_DIMS(map);
+    size[0] = (integer_t)ndim[1];
+    size[1] = (integer_t)ndim[0];
+
+    if (size[0] != inx || size[1] != iny) {
+        if (snprintf(warn_msg, 128,
+                     "Pixel map dimensions (%d, %d) != input dimensions "
+                     "(%d, %d).",
+                     size[0], size[1], inx, iny) < 1) {
+            strcpy(warn_msg, "Pixel map dimensions != input dimensions.");
+        }
+        driz_error_set_message(&error, warn_msg);
+        goto _exit;
+    }
+    if (ndim[2] != 2) {
+        driz_error_set_message(&error, "Pixel map depth (3rd dim) must be 2.");
+        goto _exit;
+    }
+
+    if (wei) {
+        get_dimensions(wei, size);
+        if (size[0] != inx || size[1] != iny) {
+            if (snprintf(warn_msg, 128,
+                         "Weights array dimensions (%d, %d) != input "
+                         "dimensions (%d, %d).",
+                         size[0], size[1], inx, iny) < 1) {
+                strcpy(warn_msg,
+                       "Weights array dimensions != input dimensions.");
+            }
+            driz_error_set_message(&error, warn_msg);
+            goto _exit;
+        }
+    }
+
+    /* Check output array dimensions */
+    ndim = PyArray_DIMS(out);
+    onx = ndim[1];
+    ony = ndim[0];
+
+    get_dimensions(wht, size);
+    if (size[0] != onx || size[1] != ony) {
+        if (snprintf(warn_msg, 128,
+                     "Output weight dimensions (%d, %d) != output dimensions "
+                     "(%d, %d).",
+                     size[0], size[1], onx, ony) < 1) {
+            strcpy(warn_msg, "Output weight dimensions != output dimensions.");
+        }
+
+        driz_error_set_message(&error, warn_msg);
+        goto _exit;
+    }
+
+    if (con) {
+        get_dimensions(con, size);
+        if (size[0] != onx || size[1] != ony) {
+            if (snprintf(warn_msg, 128,
+                         "Context dimensions (%d, %d) != output dimensions "
+                         "(%d, %d).",
+                         size[0], size[1], onx, ony) < 1) {
+                strcpy(warn_msg, "Context dimensions != output dimensions.");
+            }
+            driz_error_set_message(&error, warn_msg);
+            goto _exit;
+        }
+    }
+
+    /* Handle optional arguments that supply arrays for resampling with
+     * squared coefficients */
+    nsq_args = ((int)(oimg2 != NULL && oimg2 != Py_None)) +
+               ((int)(oout2 != NULL && oout2 != Py_None));
+    if (nsq_args == 2) {
+        if (process_array_list(oimg2, &nx, &ny, "input2", &img2_list, &nsq_arr,
+                               &error)) {
+            goto _exit;
+        }
+        if (nx != inx || ny != iny) {
+            driz_error_set_message(&error,
+                                   "'input2' arrays must have the same "
+                                   "dimensions as the 'input' array.");
+            goto _exit;
+        }
+        if (process_array_list(oout2, &nx, &ny, "output2", &out2_list,
+                               &nsq_arr_out, &error)) {
+            goto _exit;
+        }
+        if (nx != onx || ny != ony) {
+            driz_error_set_message(&error,
+                                   "'output2' arrays must have the same "
+                                   "dimensions as the 'output' array.");
+            goto _exit;
+        }
+        if (nsq_arr != nsq_arr_out) {
+            driz_error_set_message(&error,
+                                   "The number of 'output2' arrays must match "
+                                   "the number of 'input2' arrays.");
+            goto _exit;
+        }
+    } else if (nsq_args == 1) {
+        driz_error_set_message(
+            &error,
+            "'input2' and 'output2' must both be either None, "
+            "numpy.ndarray, or lists of numpy.ndarray of equal lengths.");
+        goto _exit;
+    }
+
+    /* Set the area to be processed */
+    if (xmax == 0 || xmax >= inx) {
+        xmax = inx - 1;
+    }
+    if (ymax == 0 || ymax >= iny) {
+        ymax = iny - 1;
+    }
 
     if (shrink_image_section(map, &xmin, &xmax, &ymin, &ymax)) {
         driz_error_set_message(&error,
@@ -179,7 +435,6 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
     }
 
     /* Convert strings to enumerations */
-
     if (kernel_str2enum(kernel_str, &kernel, &error) ||
         unit_str2enum(inun_str, &inun, &error)) {
         goto _exit;
@@ -228,6 +483,14 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
     p.exposure_time = expin;
     p.weight_scale = wtscl;
     p.fill_value = fill_value;
+    p.fill_value2 = fill_value2;
+    p.in_nx = inx;
+    p.in_ny = iny;
+    p.out_nx = onx;
+    p.out_ny = ony;
+    p.data2 = img2_list;
+    p.output_data2 = out2_list;
+    p.ndata2 = nsq_arr;
     p.error = &error;
 
     if (driz_error_check(&error, "xmin must be >= 0", p.xmin >= 0)) {
@@ -266,28 +529,13 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
         goto _exit;
     }
 
-    if (p.weights) {
-        get_dimensions(p.weights, wsize);
-        if (wsize[0] != isize[0] || wsize[1] != isize[1]) {
-            if (snprintf(warn_msg, 128,
-                         "Weights array dimensions (%d, %d) != input "
-                         "dimensions (%d, %d).",
-                         wsize[0], wsize[1], isize[0], isize[1]) < 1) {
-                strcpy(warn_msg,
-                       "Weights array dimensions != input dimensions.");
-            }
-            driz_error_set_message(&error, warn_msg);
-            goto _exit;
-        }
-    }
-
     if (dobox(&p)) {
         goto _exit;
     }
 
     /* Put in the fill values (if defined) */
     if (do_fill) {
-        put_fill(&p, fill_value);
+        put_fill(&p);
     }
 
 _exit:
@@ -300,13 +548,24 @@ _exit:
     Py_XDECREF(wht);
     Py_XDECREF(map);
 
+    if (nsq_arr > 0) {
+        for (i = 0; i < nsq_arr; ++i) {
+            Py_XDECREF(img2_list[i]);
+            Py_XDECREF(out2_list[i]);
+        }
+        free(img2_list);
+        free(out2_list);
+    }
+
     if (driz_error_is_set(&error)) {
-        PyErr_SetString(PyExc_ValueError, driz_error_get_message(&error));
+        if (error.type == NULL) {
+            error.type = PyExc_ValueError; /* default error type */
+        }
+        PyErr_SetString(error.type, driz_error_get_message(&error));
         return NULL;
     } else {
-        return Py_BuildValue(
-            "sii", "Callable C-based DRIZZLE Version 1.12 (28th June 2018)",
-            p.nmiss, p.nskip);
+        return Py_BuildValue("sii", "Callable C-based DRIZZLE Version 2.1.0",
+                             p.nmiss, p.nskip);
     }
 }
 
@@ -381,10 +640,10 @@ tblot(PyObject *obj, PyObject *args, PyObject *keywords) {
     get_dimensions(out, osize);
 
     if (psize[0] != osize[0] || psize[1] != osize[1]) {
-        if (snprintf(
-                warn_msg, 128,
-                "Pixel map dimensions (%d, %d) != output dimensions (%d, %d).",
-                psize[0], psize[1], osize[0], osize[1]) < 1) {
+        if (snprintf(warn_msg, 128,
+                     "Pixel map dimensions (%d, %d) != output dimensions "
+                     "(%d, %d).",
+                     psize[0], psize[1], osize[0], osize[1]) < 1) {
             strcpy(warn_msg, "Pixel map dimensions != output dimensions.");
         }
         driz_error_set_message(&error, warn_msg);
@@ -626,9 +885,10 @@ clip_polygon_wrap(PyObject *self, PyObject *args) {
 #endif
 static struct PyMethodDef cdrizzle_methods[] = {
     {"tdriz", (PyCFunction)tdriz, METH_VARARGS | METH_KEYWORDS,
-     "tdriz(image, weights, pixmap, output, counts, context, uniqid, xmin, "
-     "xmax, ymin, ymax, scale, pixfrac, kernel, in_units, expscale, wtscale, "
-     "fillstr)"},
+     "tdriz(image, weights, pixmap, output, counts, context, image2, "
+     "counts2, "
+     "output2, uniqid, xmin, xmax, ymin, ymax, scale, pixfrac, kernel, "
+     "in_units, expscale, wtscale, fillstr, fillstr2)"},
     {"tblot", (PyCFunction)tblot, METH_VARARGS | METH_KEYWORDS,
      "tblot(image, pixmap, output, xmin, xmax, ymin, ymax, scale, kscale, "
      "interp, exptime, misval, sinscl)"},

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -186,6 +186,7 @@ _exit_on_err:
         }
         free(arr_list);
     }
+    return 1;
 }
 
 static PyObject *

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -571,18 +571,6 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
         goto _exit;
     }
 
-    get_dimensions(p.pixmap, psize);
-    if (psize[0] != isize[0] || psize[1] != isize[1]) {
-        if (snprintf(
-                warn_msg, 128,
-                "Pixel map dimensions (%d, %d) != input dimensions (%d, %d).",
-                psize[0], psize[1], isize[0], isize[1]) < 1) {
-            strcpy(warn_msg, "Pixel map dimensions != input dimensions.");
-        }
-        driz_error_set_message(&error, warn_msg);
-        goto _exit;
-    }
-
     if (dobox(&p)) {
         goto _exit;
     }

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -944,7 +944,6 @@ clip_polygon_wrap(PyObject *self, PyObject *args) {
 static struct PyMethodDef cdrizzle_methods[] = {
     {"tdriz", (PyCFunction)tdriz, METH_VARARGS | METH_KEYWORDS,
      "tdriz(image, weights, pixmap, output, counts, context, image2, "
-     "counts2, "
      "output2, uniqid, xmin, xmax, ymin, ymax, scale, pixfrac, kernel, "
      "in_units, expscale, wtscale, fillstr, fillstr2)"},
     {"tblot", (PyCFunction)tblot, METH_VARARGS | METH_KEYWORDS,

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -409,7 +409,7 @@ do_kernel_point(struct driz_param_t *p) {
     struct scanner s;
     integer_t i, j, ii, jj, k;
     integer_t osize[2];
-    float scale2, d, dow, *d2 = NULL;
+    float scale2, scale4, d, dow, *d2 = NULL;
     integer_t bv;
     int xmin, xmax, ymin, ymax, n;
     int ndata2;
@@ -428,6 +428,8 @@ do_kernel_point(struct driz_param_t *p) {
     get_dimensions(p->output_data, osize);
 
     if (ndata2 > 0) {
+        scale4 = scale2 * scale2;
+
         if (!(d2 = (float *)malloc(p->ndata2 * sizeof(float)))) {
             driz_error_set(p->error, PyExc_MemoryError,
                            "Memory allocation failed.");
@@ -486,13 +488,11 @@ do_kernel_point(struct driz_param_t *p) {
                 } else {
                     /* Allow for stretching because of scale change */
                     d = get_pixel(p->data, i, j) * scale2;
-                    if (d2) {
-                        for (k = 0; k < ndata2; ++k) {
-                            if (p->data2[k]) {
-                                d2[k] = get_pixel(p->data2[k], i, j) * scale2;
-                            } else {
-                                d2[k] = 0.0f;
-                            }
+                    for (k = 0; k < ndata2; ++k) {
+                        if (p->data2[k]) {
+                            d2[k] = get_pixel(p->data2[k], i, j) * scale4;
+                        } else {
+                            d2[k] = 0.0f;
                         }
                     }
 
@@ -538,7 +538,7 @@ do_kernel_gaussian(struct driz_param_t *p) {
     integer_t osize[2];
     float d, dow, *d2 = NULL;
     double gaussian_efac, gaussian_es;
-    double pfo, ac, scale2, xxi, xxa, yyi, yya, w, ddx, ddy, r2, dover;
+    double pfo, ac, scale2, scale4, xxi, xxa, yyi, yya, w, ddx, ddy, r2, dover;
     const double nsig = 2.5;
     int xmin, xmax, ymin, ymax, n;
     int ndata2;
@@ -569,6 +569,7 @@ do_kernel_gaussian(struct driz_param_t *p) {
     get_dimensions(p->output_data, osize);
 
     if (ndata2 > 0) {
+        scale4 = scale2 * scale2;
         if (!(d2 = (float *)malloc(p->ndata2 * sizeof(float)))) {
             driz_error_set(p->error, PyExc_MemoryError,
                            "Memory allocation failed.");
@@ -631,13 +632,11 @@ do_kernel_gaussian(struct driz_param_t *p) {
 
                 /* Allow for stretching because of scale change */
                 d = get_pixel(p->data, i, j) * scale2;
-                if (d2) {
-                    for (k = 0; k < ndata2; ++k) {
-                        if (p->data2[k]) {
-                            d2[k] = get_pixel(p->data2[k], i, j) * scale2;
-                        } else {
-                            d2[k] = 0.0f;
-                        }
+                for (k = 0; k < ndata2; ++k) {
+                    if (p->data2[k]) {
+                        d2[k] = get_pixel(p->data2[k], i, j) * scale4;
+                    } else {
+                        d2[k] = 0.0f;
                     }
                 }
 
@@ -700,7 +699,7 @@ do_kernel_lanczos(struct driz_param_t *p) {
     struct scanner s;
     integer_t bv, i, j, ii, jj, k, nxi, nxa, nyi, nya, nhit, ix, iy;
     integer_t osize[2];
-    float scale2, d, dow, *d2 = NULL;
+    float scale2, scale4, d, dow, *d2 = NULL;
     double pfo, xx, yy, xxi, xxa, yyi, yya, w, dx, dy, dover;
     int kernel_order;
     struct lanczos_param_t lanczos;
@@ -740,6 +739,8 @@ do_kernel_lanczos(struct driz_param_t *p) {
     get_dimensions(p->output_data, osize);
 
     if (ndata2 > 0) {
+        scale4 = scale2 * scale2;
+
         if (!(d2 = (float *)malloc(p->ndata2 * sizeof(float)))) {
             driz_error_set(p->error, PyExc_MemoryError,
                            "Memory allocation failed.");
@@ -799,13 +800,11 @@ do_kernel_lanczos(struct driz_param_t *p) {
 
                 /* Allow for stretching because of scale change */
                 d = get_pixel(p->data, i, j) * scale2;
-                if (d2) {
-                    for (k = 0; k < ndata2; ++k) {
-                        if (p->data2[k]) {
-                            d2[k] = get_pixel(p->data2[k], i, j) * scale2;
-                        } else {
-                            d2[k] = 0.0f;
-                        }
+                for (k = 0; k < ndata2; ++k) {
+                    if (p->data2[k]) {
+                        d2[k] = get_pixel(p->data2[k], i, j) * scale4;
+                    } else {
+                        d2[k] = 0.0f;
                     }
                 }
 
@@ -876,7 +875,7 @@ do_kernel_turbo(struct driz_param_t *p) {
     integer_t bv, i, j, ii, jj, k, nxi, nxa, nyi, nya, nhit, iis, iie, jjs, jje;
     integer_t osize[2];
     float d, dow, *d2 = NULL;
-    double pfo, scale2, ac;
+    double pfo, scale2, scale4, ac;
     double xxi, xxa, yyi, yya, w, dover;
     int xmin, xmax, ymin, ymax, n;
     int ndata2;
@@ -899,6 +898,8 @@ do_kernel_turbo(struct driz_param_t *p) {
     get_dimensions(p->output_data, osize);
 
     if (ndata2 > 0) {
+        scale4 = scale2 * scale2;
+
         if (!(d2 = (float *)malloc(ndata2 * sizeof(float)))) {
             driz_error_set(p->error, PyExc_MemoryError,
                            "Memory allocation failed.");
@@ -968,13 +969,11 @@ do_kernel_turbo(struct driz_param_t *p) {
 
                 /* Allow for stretching because of scale change */
                 d = get_pixel(p->data, i, j) * scale2;
-                if (d2) {
-                    for (k = 0; k < ndata2; ++k) {
-                        if (p->data2[k]) {
-                            d2[k] = get_pixel(p->data2[k], i, j) * scale2;
-                        } else {
-                            d2[k] = 0.0f;
-                        }
+                for (k = 0; k < ndata2; ++k) {
+                    if (p->data2[k]) {
+                        d2[k] = get_pixel(p->data2[k], i, j) * scale4;
+                    } else {
+                        d2[k] = 0.0f;
                     }
                 }
 
@@ -1039,7 +1038,7 @@ int
 do_kernel_square(struct driz_param_t *p) {
     integer_t bv, i, j, ii, jj, k, min_ii, max_ii, min_jj, max_jj, nhit;
     integer_t osize[2], mapsize[2];
-    float scale2, d, dow, *d2 = NULL;
+    float scale2, scale4, d, dow, *d2 = NULL;
     double dh, jaco, tem, dover, w;
 
     double xin[4], yin[4], xout[4], yout[4];
@@ -1068,6 +1067,8 @@ do_kernel_square(struct driz_param_t *p) {
     get_dimensions(p->pixmap, mapsize);
 
     if (ndata2 > 0) {
+        scale4 = scale2 * scale2;
+
         if (!(d2 = (float *)malloc(p->ndata2 * sizeof(float)))) {
             driz_error_set(p->error, PyExc_MemoryError,
                            "Memory allocation failed.");
@@ -1157,13 +1158,11 @@ do_kernel_square(struct driz_param_t *p) {
 
             /* Allow for stretching because of scale change */
             d = get_pixel(p->data, i, j) * scale2;
-            if (d2) {
-                for (k = 0; k < ndata2; ++k) {
-                    if (p->data2[k]) {
-                        d2[k] = get_pixel(p->data2[k], i, j) * scale2;
-                    } else {
-                        d2[k] = 0.0f;
-                    }
+            for (k = 0; k < ndata2; ++k) {
+                if (p->data2[k]) {
+                    d2[k] = get_pixel(p->data2[k], i, j) * scale4;
+                } else {
+                    d2[k] = 0.0f;
                 }
             }
 

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -440,7 +440,7 @@ do_kernel_point(struct driz_param_t *p) {
             return 1;
         }
         for (i = 0; i < ndata2; ++i) {
-            if (!p->output_data2[k]) {
+            if (!p->output_data2[i]) {
                 driz_error_set(
                     p->error, PyExc_RuntimeError,
                     "Some arrays in 'output_data2' have invalid pointers.");
@@ -581,7 +581,7 @@ do_kernel_gaussian(struct driz_param_t *p) {
             return 1;
         }
         for (i = 0; i < ndata2; ++i) {
-            if (!p->output_data2[k]) {
+            if (!p->output_data2[i]) {
                 driz_error_set(
                     p->error, PyExc_RuntimeError,
                     "Some arrays in 'output_data2' have invalid pointers.");
@@ -752,7 +752,7 @@ do_kernel_lanczos(struct driz_param_t *p) {
             return 1;
         }
         for (i = 0; i < ndata2; ++i) {
-            if (!p->output_data2[k]) {
+            if (!p->output_data2[i]) {
                 driz_error_set(
                     p->error, PyExc_RuntimeError,
                     "Some arrays in 'output_data2' have invalid pointers.");
@@ -911,7 +911,7 @@ do_kernel_turbo(struct driz_param_t *p) {
             return 1;
         }
         for (i = 0; i < ndata2; ++i) {
-            if (!p->output_data2[k]) {
+            if (!p->output_data2[i]) {
                 driz_error_set(
                     p->error, PyExc_RuntimeError,
                     "Some arrays in 'output_data2' have invalid pointers.");
@@ -1080,7 +1080,7 @@ do_kernel_square(struct driz_param_t *p) {
             return 1;
         }
         for (i = 0; i < ndata2; ++i) {
-            if (!p->output_data2[k]) {
+            if (!p->output_data2[i]) {
                 driz_error_set(
                     p->error, PyExc_RuntimeError,
                     "Some arrays in 'output_data2' have invalid pointers.");

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -559,14 +559,15 @@ do_kernel_point_var(struct driz_param_t *p) {
                        that we DON'T scale by the Jacobian as it hasn't been
                        calculated */
                     if (p->weights) {
-                        dow = get_pixel(p->weights, i, j) * p->weight_scale;
+                        dow = (float)get_pixel(p->weights, i, j) *
+                              p->weight_scale;
                     } else {
-                        dow = 1.0;
+                        dow = 1.0f;
                     }
 
                     /* If we are creating or modifying the context image,
                        we do so here. */
-                    if (p->output_context && dow > 0.0) {
+                    if (p->output_context && dow > 0.0f) {
                         set_bit(p->output_context, ii, jj, bv);
                     }
 
@@ -729,7 +730,7 @@ do_kernel_gaussian_var(struct driz_param_t *p) {
 
                         /* If we are create or modifying the context image, we
                            do so here. */
-                        if (p->output_context && dow > 0.0) {
+                        if (p->output_context && dow > 0.0f) {
                             set_bit(p->output_context, ii, jj, bv);
                         }
 
@@ -907,7 +908,7 @@ do_kernel_lanczos_var(struct driz_param_t *p) {
 
                         /* If we are create or modifying the context image, we
                            do so here. */
-                        if (p->output_context && dow > 0.0) {
+                        if (p->output_context && dow > 0.0f) {
                             set_bit(p->output_context, ii, jj, bv);
                         }
 
@@ -1075,7 +1076,7 @@ do_kernel_turbo_var(struct driz_param_t *p) {
 
                             /* If we are create or modifying the context image,
                                we do so here. */
-                            if (p->output_context && dow > 0.0) {
+                            if (p->output_context && dow > 0.0f) {
                                 set_bit(p->output_context, ii, jj, bv);
                             }
 
@@ -1149,6 +1150,7 @@ do_kernel_square_var(struct driz_param_t *p) {
             driz_error_set(p->error, PyExc_RuntimeError,
                            "'output_data2' must be a valid pointer when "
                            "'data2' is valid.");
+            free(d2);
             return 1;
         }
         for (i = 0; i < ndata2; ++i) {
@@ -1156,6 +1158,7 @@ do_kernel_square_var(struct driz_param_t *p) {
                 driz_error_set(
                     p->error, PyExc_RuntimeError,
                     "Some arrays in 'output_data2' have invalid pointers.");
+                free(d2);
                 return 1;
             }
         }
@@ -1228,10 +1231,10 @@ do_kernel_square_var(struct driz_param_t *p) {
                            (xout[0] - xout[2]) * (yout[1] - yout[3]));
 
             /* Allow for stretching because of scale change */
-            d = get_pixel(p->data, i, j) * scale2;
+            d = (float)get_pixel(p->data, i, j) * scale2;
             for (k = 0; k < ndata2; ++k) {
                 if (p->data2[k]) {
-                    d2[k] = get_pixel(p->data2[k], i, j) * scale4;
+                    d2[k] = (float)get_pixel(p->data2[k], i, j) * scale4;
                 } else {
                     d2[k] = 0.0f;
                 }
@@ -1267,15 +1270,12 @@ do_kernel_square_var(struct driz_param_t *p) {
 
                         /* If we are creating or modifying the context image we
                             do so here */
-                        if (p->output_context && dow > 0.0) {
+                        if (p->output_context && dow > 0.0f) {
                             set_bit(p->output_context, ii, jj, bv);
                         }
-                        // if (update_handler(p, ii, jj, d, dow, d2)) {
-                        //     free(d2);
-                        //     return 1;
-                        // }
 
                         if (update_data_var(p, ii, jj, d, dow, d2)) {
+                            free(d2);
                             return 1;
                         }
                     }
@@ -1291,6 +1291,7 @@ do_kernel_square_var(struct driz_param_t *p) {
     }
 
     driz_log_message("ending do_kernel_square");
+    free(d2);
     return 0;
 }
 
@@ -1354,20 +1355,21 @@ do_kernel_point(struct driz_param_t *p) {
 
                 } else {
                     /* Allow for stretching because of scale change */
-                    d = get_pixel(p->data, i, j) * scale2;
+                    d = (float)get_pixel(p->data, i, j) * scale2;
 
                     /* Scale the weighting mask by the scale factor.  Note that
                        we DON'T scale by the Jacobian as it hasn't been
                        calculated */
                     if (p->weights) {
-                        dow = get_pixel(p->weights, i, j) * p->weight_scale;
+                        dow = (float)get_pixel(p->weights, i, j) *
+                              p->weight_scale;
                     } else {
-                        dow = 1.0;
+                        dow = 1.0f;
                     }
 
                     /* If we are creating or modifying the context image,
                        we do so here. */
-                    if (p->output_context && dow > 0.0) {
+                    if (p->output_context && dow > 0.0f) {
                         set_bit(p->output_context, ii, jj, bv);
                     }
 
@@ -1492,7 +1494,7 @@ do_kernel_gaussian(struct driz_param_t *p) {
 
                         /* If we are create or modifying the context image, we
                            do so here. */
-                        if (p->output_context && dow > 0.0) {
+                        if (p->output_context && dow > 0.0f) {
                             set_bit(p->output_context, ii, jj, bv);
                         }
 
@@ -1628,7 +1630,7 @@ do_kernel_lanczos(struct driz_param_t *p) {
 
                         /* If we are create or modifying the context image, we
                            do so here. */
-                        if (p->output_context && dow > 0.0) {
+                        if (p->output_context && dow > 0.0f) {
                             set_bit(p->output_context, ii, jj, bv);
                         }
 
@@ -1757,7 +1759,7 @@ do_kernel_turbo(struct driz_param_t *p) {
 
                             /* If we are create or modifying the context image,
                                we do so here. */
-                            if (p->output_context && dow > 0.0) {
+                            if (p->output_context && dow > 0.0f) {
                                 set_bit(p->output_context, ii, jj, bv);
                             }
 
@@ -1914,7 +1916,7 @@ do_kernel_square(struct driz_param_t *p) {
 
                         /* If we are creating or modifying the context image we
                             do so here */
-                        if (p->output_context && dow > 0.0) {
+                        if (p->output_context && dow > 0.0f) {
                             set_bit(p->output_context, ii, jj, bv);
                         }
 

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -199,6 +199,9 @@ void
 print_context(char *title, struct driz_param_t *p, int lo, int hi) {
     int j, i;
     integer_t bv;
+    if (!p->output_context) {
+        return;
+    }
 
     if (logptr) {
         bv = 1;


### PR DESCRIPTION
This PR adds support for resampling and adding resampled (error, variance) images with squared weights. This is to facilitate standard error propagation.