### PR TITLE
Fix a bug in Drizzle when out_img=None and fillval is INDEF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,14 @@
 Release Notes
 =============
 
+
 2.0.2 (unreleased)
 ==================
+
+- Fix a bug in ``resample.Drizzle`` due to which initially, before adding
+  the first image, ``Drizzle.output_img`` is not filled with ``NaN`` when
+  ``fillval`` is either ``INDEF``, ``NAN``, ``None`` *and* the ``Drizzle``
+  object was initialized with ``out_img=None``. [#170]
 
 - Fixes a crash when ``Drizzle`` is initialized with ``disable_ctx``
   set to ``True``. [#180]

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -76,23 +76,24 @@ class Drizzle:
     information about which input image has contributed to the corresponding
     pixel in the resampled data array. Context image uses 32 bit integers to
     encode this information and hence it can keep track of only 32 input images.
-    First bit corresponds to the first input image, second bit corrsponds to the
-    second input image, and so on. We call this (0-indexed) order "context ID"
-    which is represented by the ``ctx_id`` parameter/property. If the number of
+    The first bit corresponds to the first input image, the second bit
+    corresponds to the second input image, and so on.
+    We call this (0-indexed) order "context ID" which is represented by
+    the ``ctx_id`` parameter/property. If the number of
     input images exceeds 32, then it is necessary to have multiple context
-    images ("planes") to hold information about all input images with the first
+    images ("planes") to hold information about all input images, with the first
     plane encoding which of the first 32 images contributed to the output data
-    pixel, second plane representing next 32 input images (number 33-64), etc.
-    For this reason, context array is either a 2D array (if the total number
-    of resampled images is less than 33) of the type `numpy.int32` and shape
-    ``(ny, nx)`` or a a 3D array of shape ``(np, ny, nx)`` where ``nx`` and
-    ``ny`` are dimensions of image's data. ``np`` is the number of "planes"
-    equal to ``(number of input images - 1) // 32 + 1``. If a bit at position
-    ``k`` in a pixel with coordinates ``(p, y, x)`` is 0 then input image number
-    ``32 * p + k`` (0-indexed) did not contribute to the output data pixel
-    with array coordinates ``(y, x)`` and if that bit is 1 then input image
-    number ``32 * p + k`` did contribute to the pixel ``(y, x)`` in the
-    resampled image.
+    pixel, the second plane representing next 32 input images (number 33-64),
+    etc. For this reason, context array is either a 2D array (if the total
+    number of resampled images is less than 33) of the type `numpy.int32` and
+    shape ``(ny, nx)`` or a a 3D array of shape ``(np, ny, nx)`` where ``nx``
+    and ``ny`` are dimensions of the image data. ``np`` is the number of
+    "planes" computed as ``(number of input images - 1) // 32 + 1``. If a bit at
+    position ``k`` in a pixel with coordinates ``(p, y, x)`` is 0, then input
+    image number ``32 * p + k`` (0-indexed) did not contribute to the output
+    data pixel with array coordinates ``(y, x)`` and if that bit is 1, then
+    input image number ``32 * p + k`` did contribute to the pixel ``(y, x)``
+    in the resampled image.
 
     As an example, let's assume we have 8 input images. Then, when ``out_ctx``
     pixel values are displayed using binary representation (and decimal in
@@ -413,7 +414,12 @@ class Drizzle:
                     )
 
         if out_img is None:
-            self._out_img = np.zeros(out_shape, dtype=np.float32)
+            self._out_img = np.empty(out_shape, dtype=np.float32)
+            if self._fillval.upper() in ["INDEF", "NAN"]:
+                fillval = np.nan
+            else:
+                fillval = float(self._fillval)
+            self._out_img[:, :] = fillval
         else:
             self._out_img = out_img
 

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -414,12 +414,11 @@ class Drizzle:
                     )
 
         if out_img is None:
-            self._out_img = np.empty(out_shape, dtype=np.float32)
             if self._fillval.upper() in ["INDEF", "NAN"]:
                 fillval = np.nan
             else:
                 fillval = float(self._fillval)
-            self._out_img[:, :] = fillval
+            self._out_img = np.full(out_shape, fillval, dtype=np.float32)
         else:
             self._out_img = out_img
 

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -1222,4 +1222,4 @@ def test_nan_fillval(fillval):
         out_shape=(20, 20)
     )
 
-    assert np.all(~np.isfinite(driz.out_img))
+    assert np.all(np.isnan(driz.out_img))

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -1210,3 +1210,16 @@ def test_resample_disable_ctx():
     )
 
     driz.add_image(in_sci, exptime=1.0, pixmap=pixmap)
+
+
+@pytest.mark.parametrize(
+    "fillval", ["NaN", "INDEF", "", None]
+)
+def test_nan_fillval(fillval):
+    driz = resample.Drizzle(
+        kernel='square',
+        fillval=fillval,
+        out_shape=(20, 20)
+    )
+
+    assert np.all(~np.isfinite(driz.out_img))

--- a/drizzle/tests/test_utils.py
+++ b/drizzle/tests/test_utils.py
@@ -2,14 +2,13 @@ import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_equal
 
+from drizzle.tests.helpers import wcs_from_file
 from drizzle.utils import (
     _estimate_pixel_scale,
     calc_pixmap,
     decode_context,
     estimate_pixel_scale_ratio,
 )
-
-from .helpers import wcs_from_file
 
 
 def test_map_rectangular():


### PR DESCRIPTION
Fixes #169

Regression tests:

JWST: https://github.com/spacetelescope/RegressionTests/actions/runs/13406783281
Roman: https://github.com/spacetelescope/RegressionTests/actions/runs/13406785388