### PR TITLE
[build] remove maintainer password from PyPI publish workflow in lieu of trusted publisher attestation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,4 @@ jobs:
         - cp3*-win_amd64
       sdist: true
       test_command: python -c "from drizzle import cdrizzle"
-    secrets:
-      pypi_token: ${{ secrets.PYPI_PASSWORD_STSCI_MAINTAINER }}
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example RCAL-1234: <Fix a bug> -->
Resolves [SCSB-199](https://jira.stsci.edu/browse/SCSB-199)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
- [x] add a Trusted Publisher configuration to the PyPI project by visiting https://pypi.org/manage/project/drizzle/settings/publishing/?provider=github&owner=spacetelescope&repository=drizzle&workflow_filename=build.yml
- [x] remove `pypi_token` (STScI PyPI maintainer password) from build workflow
- [ ] wait for https://github.com/pypi/warehouse/issues/11096 to be resolved