### PR TITLE
Use random weights in the unit test for multi-src flux conserve

### DIFF
--- a/drizzle/utils.py
+++ b/drizzle/utils.py
@@ -96,7 +96,7 @@ def calc_pixmap(wcs_from, wcs_to, shape=None, disable_bbox="to"):
                 bbox_from = (bbox_from, )
             if nd > 1:
                 shape = tuple(
-                    int(math.ceil(lim[1] + 0.5)) for lim in bbox_from[::-1]
+                    math.ceil(lim[1] + 0.5) for lim in bbox_from[::-1]
                 )
 
     if shape is None:


### PR DESCRIPTION
Improves unit test added in #177 by using random weights for input image pixels compared to constant weight set to one in the original test.