### PR TITLE
[SCSB-205] `project.license.file` -> `project.license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 dependencies = [
     "numpy",
 ]
+license-files = ["LICENSE.rst"]
 dynamic = [
     "version",
 ]
@@ -15,10 +16,6 @@ dynamic = [
 [project.readme]
 file = "README.rst"
 content-type = "text/x-rst"
-
-[project.license]
-file = "LICENSE.rst"
-content-type = "text/plain"
 
 [project.urls]
 Homepage = "https://github.com/spacetelescope/drizzle"


### PR DESCRIPTION
the `project.license` entry is changing to just use SPDX expressions; license files are moving to `project.license-files` ([PEP 639](https://peps.python.org/pep-0639/))