### PR TITLE
Fix failing tests due to Python 3.13.4 win32 GIL issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           coverage: codecov
         - macos: py3-xdist
         - windows: py3-xdist
+          # exclude Python 1.13.4, see https://github.com/python/cpython/issues/135151
+          python-version: '>=3.13.5 <3.14'
         - linux: py3-devdeps-xdist
       toxdeps: tox-uv
     secrets:

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,13 @@ def get_extensions():
     cfg['include_dirs'].append(srcdir)
 
     if sys.platform == 'win32':
-        cfg['define_macros'].append(('WIN32', None))
-        cfg['define_macros'].append(('__STDC__', 1))
-        cfg['define_macros'].append(('_CRT_SECURE_NO_WARNINGS', None))
+        cfg['define_macros'].extend(
+            [
+                ('WIN32', None),
+                ('__STDC__', 1),
+                ('_CRT_SECURE_NO_WARNINGS', None),
+            ]
+        )
     else:
         cfg['libraries'].append('m')
         cfg['extra_compile_args'] = [


### PR DESCRIPTION
Currently `drizzle` build on CI is failing with:
```
LINK : fatal error LNK1104: cannot open file 'python313t.lib'
```
apparently due to https://github.com/python/cpython/issues/135151

This PR implements the solution is to ignore 1.13.4 as in https://github.com/spacetelescope/stcal/pull/351 