### PR TITLE
fillval and fillval2 should be independent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Release Notes
 
 - Added support for resampling and co-adding images using squared weights.
   This can be helpful when resampling variance arrays for the purpose of
-  performing propagation of uncertainties. [#163]
+  performing propagation of uncertainties. [#163, #199]
 
 
 2.1.1 (2025-08-14)

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -577,7 +577,7 @@ tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
 
     /* Put in the fill values (if defined) */
     if (do_fill) {
-        put_fill(&p);
+        put_fill(&p, do_fill, do_fill2);
     }
 
 _exit:

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -391,7 +391,7 @@ was: FILALU
 void create_lanczos_lut(const int kernel_order, const size_t npix,
                         const float del, float *lanczos_lut);
 
-void put_fill(struct driz_param_t *p);
+void put_fill(struct driz_param_t *p, int fill, int fill2);
 
 /**
  Calculate the refractive index of MgF2 for a given C wavelength (in


### PR DESCRIPTION
This PR fixes a bug (in not yet released code) in `tdriz()` due to which `fillval2` may not be applied if `fillval` is set to 0.