### PR TITLE
Remove unused variables and fix function type conversion warnings

### DIFF
--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -190,7 +190,9 @@ _exit_on_err:
 }
 
 static PyObject *
-tdriz(PyObject *obj UNUSED_PARAM, PyObject *args, PyObject *keywords) {
+tdriz(PyObject *self, PyObject *args, PyObject *keywords) {
+    (void)self;
+
     const char *kwlist[] = {
         "input",   "weights", "pixmap",   "output", "counts",   "context",
         "input2",  "output2", "uniqid",   "xmin",   "xmax",     "ymin",
@@ -621,7 +623,9 @@ _exit:
  */
 
 static PyObject *
-tblot(PyObject *obj, PyObject *args, PyObject *keywords) {
+tblot(PyObject *self, PyObject *args, PyObject *keywords) {
+    (void)self;
+
     const char *kwlist[] = {"source",  "pixmap", "output", "xmin",   "xmax",
                             "ymin",    "ymax",   "scale",  "kscale", "interp",
                             "exptime", "misval", "sinscl", NULL};
@@ -771,10 +775,11 @@ _exit:
 
 static PyObject *
 test_cdrizzle(PyObject *self, PyObject *args) {
+    (void)self;
+
     PyObject *data, *weights, *pixmap, *output_data, *output_counts,
         *output_context;
     PyArrayObject *dat, *wei, *map, *odat, *ocnt, *ocon;
-
     int argc = 1;
     char *argv[] = {"utest_cdrizzle", NULL};
 
@@ -825,6 +830,8 @@ test_cdrizzle(PyObject *self, PyObject *args) {
 
 static PyObject *
 invert_pixmap_wrap(PyObject *self, PyObject *args) {
+    (void)self;
+
     PyObject *pixmap, *xyout, *bbox;
     PyArrayObject *xyout_arr, *pixmap_arr, *bbox_arr;
     struct driz_param_t par;
@@ -890,6 +897,8 @@ invert_pixmap_wrap(PyObject *self, PyObject *args) {
 
 static PyObject *
 clip_polygon_wrap(PyObject *self, PyObject *args) {
+    (void)self;
+
     int k;
     PyObject *pin, *qin;
     PyArrayObject *pin_arr, *qin_arr;
@@ -947,18 +956,20 @@ clip_polygon_wrap(PyObject *self, PyObject *args) {
 #pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
 #endif
 static struct PyMethodDef cdrizzle_methods[] = {
-    {"tdriz", (PyCFunction)tdriz, METH_VARARGS | METH_KEYWORDS,
+    {"tdriz", (PyCFunction)(void (*)(void))tdriz, METH_VARARGS | METH_KEYWORDS,
      "tdriz(image, weights, pixmap, output, counts, context, image2, "
      "output2, uniqid, xmin, xmax, ymin, ymax, scale, pixfrac, kernel, "
      "in_units, expscale, wtscale, fillstr, fillstr2)"},
-    {"tblot", (PyCFunction)tblot, METH_VARARGS | METH_KEYWORDS,
+    {"tblot", (PyCFunction)(void (*)(void))(PyCFunctionWithKeywords)tblot,
+     METH_VARARGS | METH_KEYWORDS,
      "tblot(image, pixmap, output, xmin, xmax, ymin, ymax, scale, kscale, "
      "interp, exptime, misval, sinscl)"},
-    {"test_cdrizzle", test_cdrizzle, METH_VARARGS,
+    {"test_cdrizzle", (PyCFunction)test_cdrizzle, METH_VARARGS,
      "test_cdrizzle(data, weights, pixmap, output_data, output_counts)"},
-    {"invert_pixmap", invert_pixmap_wrap, METH_VARARGS,
+    {"invert_pixmap", (PyCFunction)invert_pixmap_wrap, METH_VARARGS,
      "invert_pixmap(pixmap, xyout, bbox)"},
-    {"clip_polygon", clip_polygon_wrap, METH_VARARGS, "clip_polygon(p, q)"},
+    {"clip_polygon", (PyCFunction)clip_polygon_wrap, METH_VARARGS,
+     "clip_polygon(p, q)"},
     {NULL, NULL} /* sentinel */
 };
 #if defined(__GNUC__)

--- a/src/cdrizzleblot.c
+++ b/src/cdrizzleblot.c
@@ -257,11 +257,14 @@ ii_bipoly5(const float *coeff /* [len_coeff][len_coeff] */,
  */
 
 static int
-interpolate_nearest_neighbor(const void *state UNUSED_PARAM,
-                             PyArrayObject *data, const float x, const float y,
+interpolate_nearest_neighbor(const void *state, PyArrayObject *data,
+                             const float x, const float y,
                              /* Output parameters */
-                             float *value,
-                             struct driz_error_t *error UNUSED_PARAM) {
+                             float *value, struct driz_error_t *error) {
+    /* Unused parameters: */
+    (void)state;
+    (void)error;
+
     integer_t isize[2];
     get_dimensions(data, isize);
 
@@ -282,10 +285,14 @@ interpolate_nearest_neighbor(const void *state UNUSED_PARAM,
  */
 
 static int
-interpolate_bilinear(const void *state UNUSED_PARAM, PyArrayObject *data,
-                     const float x, const float y,
+interpolate_bilinear(const void *state, PyArrayObject *data, const float x,
+                     const float y,
                      /* Output parameters */
-                     float *value, struct driz_error_t *error UNUSED_PARAM) {
+                     float *value, struct driz_error_t *error) {
+    /* Unused parameters: */
+    (void)state;
+    (void)error;
+
     integer_t nx, ny;
     float sx, tx, sy, ty, f00;
     integer_t isize[2];
@@ -345,10 +352,14 @@ interpolate_bilinear(const void *state UNUSED_PARAM, PyArrayObject *data,
  */
 
 static int
-interpolate_poly3(const void *state UNUSED_PARAM, PyArrayObject *data,
-                  const float x, const float y,
+interpolate_poly3(const void *state, PyArrayObject *data, const float x,
+                  const float y,
                   /* Output parameters */
-                  float *value, struct driz_error_t *error UNUSED_PARAM) {
+                  float *value, struct driz_error_t *error) {
+    /* Unused parameters: */
+    (void)state;
+    (void)error;
+
     integer_t nx, ny;
     const integer_t rowleh = 4;
     const integer_t nterms = 4;
@@ -451,10 +462,13 @@ interpolate_poly3(const void *state UNUSED_PARAM, PyArrayObject *data,
  */
 
 static int
-interpolate_poly5(const void *state UNUSED_PARAM, PyArrayObject *data,
-                  const float x, const float y,
+interpolate_poly5(const void *state, PyArrayObject *data, const float x,
+                  const float y,
                   /* Output parameters */
-                  float *value, struct driz_error_t *error UNUSED_PARAM) {
+                  float *value, struct driz_error_t *error) {
+    (void)state;
+    (void)error;
+
     integer_t nx, ny;
     const integer_t rowleh = 6;
     const integer_t nterms = 6;
@@ -554,7 +568,10 @@ interpolate_sinc_(PyArrayObject *data, const integer_t firstt,
                   const float *y /*[npts]*/, const float mindx,
                   const float mindy, const float sinscl,
                   /* Output parameters */
-                  float *value, struct driz_error_t *error UNUSED_PARAM) {
+                  float *value, struct driz_error_t *error) {
+    /* Unused parameters: */
+    (void)error;
+
     const integer_t nconv = INTERPOLATE_SINC_NCONV;
     const integer_t nsinc = (nconv - 1) / 2;
     /* TODO: This is to match Fortan, but is probably technically less precise
@@ -771,7 +788,10 @@ static int
 interpolate_lanczos(const void *state, PyArrayObject *data, const float x,
                     const float y,
                     /* Output parameters */
-                    float *value, struct driz_error_t *error UNUSED_PARAM) {
+                    float *value, struct driz_error_t *error) {
+    /* Unused parameters: */
+    (void)error;
+
     integer_t ixs, iys, ixe, iye;
     integer_t xoff, yoff;
     float luty, sum;

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -200,22 +200,25 @@ interpolate_four_points(struct driz_param_t *par, int ixcen, int iycen,
                         double h, double *x1, double *x2, double *x3,
                         double *x4, double *y1, double *y2, double *y3,
                         double *y4) {
-    int i, j, nx2, ny2;
-    double fac;
+    int i, j;
+#if !defined(NDEBUG)
     npy_intp *ndim;
+    int nx2, ny2;
+#endif
+    double fac;
     double f[3][3], g[3][3];
     double *p;
-    PyArrayObject *pixmap;
-
-    pixmap = par->pixmap;
+    PyArrayObject *pixmap = par->pixmap;
 
     /* Bilinear interpolation from
        https://en.wikipedia.org/wiki/Bilinear_interpolation#On_the_unit_square
     */
 
+#if !defined(NDEBUG)
     ndim = PyArray_DIMS(pixmap);
     nx2 = (int)ndim[1] - 2;
     ny2 = (int)ndim[0] - 2;
+#endif
 
     /* This is written specifically for the case where I am enclosed
      * by nine pixels.  Since the increments are the same in x and y,

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -54,12 +54,6 @@ void driz_error_unset(struct driz_error_t *error);
 #define CLAMP_ABOVE(x, low)  (((x) < low) ? (low) : (x))
 #define CLAMP_BELOW(x, high) (((x) > high) ? (high) : (x))
 
-#ifdef __GNUC__
-#define UNUSED_PARAM __attribute__((unused))
-#else
-#define UNUSED_PARAM
-#endif
-
 #define MAX_DOUBLE 1.7976931348623158e+308
 #define MIN_DOUBLE 2.2250738585072014e-308
 


### PR DESCRIPTION
This PR removes a couple of unused variables and fixes compiler warnings related to function type conversion.