### PR TITLE
Add a warning about ignoring pixfrac with lanczos kernel

### DIFF
--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -733,8 +733,8 @@ do_kernel_gaussian_var(struct driz_param_t *p) {
 
                         dow = (float)dover * w;
 
-                        /* If we are create or modifying the context image, we
-                           do so here. */
+                        /* If we are creating or modifying the context image,
+                           we do so here. */
                         if (p->output_context && dow > 0.0f) {
                             set_bit(p->output_context, ii, jj, bv);
                         }
@@ -781,7 +781,9 @@ do_kernel_lanczos_var(struct driz_param_t *p) {
     int ndata2;
 
     if (fabs(p->pixel_fraction - 1.0) > 1.0e-5) {
-        // TODO: log a warning that pixfrac is ignored and assumed to be 1.0
+        py_warning(
+            "In lanczos kernel, pixel_fraction is ignored and "
+            "assumed to be 1.0");
     }
 
     ndata2 = p->ndata2;
@@ -911,8 +913,8 @@ do_kernel_lanczos_var(struct driz_param_t *p) {
 
                         dow = (float)(dover * w);
 
-                        /* If we are create or modifying the context image, we
-                           do so here. */
+                        /* If we are creating or modifying the context image,
+                           we do so here. */
                         if (p->output_context && dow > 0.0f) {
                             set_bit(p->output_context, ii, jj, bv);
                         }
@@ -1076,8 +1078,8 @@ do_kernel_turbo_var(struct driz_param_t *p) {
 
                             dow = (float)(dover * w);
 
-                            /* If we are create or modifying the context image,
-                               we do so here. */
+                            /* If we are creating or modifying the context
+                               image, we do so here. */
                             if (p->output_context && dow > 0.0f) {
                                 set_bit(p->output_context, ii, jj, bv);
                             }
@@ -1499,8 +1501,8 @@ do_kernel_gaussian(struct driz_param_t *p) {
 
                         dow = (float)dover * w;
 
-                        /* If we are create or modifying the context image, we
-                           do so here. */
+                        /* If we are creating or modifying the context image,
+                           we do so here. */
                         if (p->output_context && dow > 0.0f) {
                             set_bit(p->output_context, ii, jj, bv);
                         }
@@ -1544,7 +1546,9 @@ do_kernel_lanczos(struct driz_param_t *p) {
     int xmin, xmax, ymin, ymax, n;
 
     if (fabs(p->pixel_fraction - 1.0) > 1.0e-5) {
-        // TODO: log a warning that pixfrac is ignored and assumed to be 1.0
+        py_warning(
+            "In lanczos kernel, pixel_fraction is ignored and "
+            "assumed to be 1.0");
     }
 
     scale2 = p->scale * p->scale;
@@ -1635,8 +1639,8 @@ do_kernel_lanczos(struct driz_param_t *p) {
 
                         dow = (float)(dover * w);
 
-                        /* If we are create or modifying the context image, we
-                           do so here. */
+                        /* If we are creating or modifying the context image,
+                           we do so here. */
                         if (p->output_context && dow > 0.0f) {
                             set_bit(p->output_context, ii, jj, bv);
                         }
@@ -1762,8 +1766,8 @@ do_kernel_turbo(struct driz_param_t *p) {
 
                             dow = (float)(dover * w);
 
-                            /* If we are create or modifying the context image,
-                               we do so here. */
+                            /* If we are creating or modifying the context
+                               image, we do so here. */
                             if (p->output_context && dow > 0.0f) {
                                 set_bit(p->output_context, ii, jj, bv);
                             }

--- a/src/cdrizzleutil.c
+++ b/src/cdrizzleutil.c
@@ -14,6 +14,7 @@
 /*****************************************************************
  ERROR HANDLING
 */
+
 void
 driz_error_init(struct driz_error_t *error) {
     assert(error);
@@ -91,6 +92,19 @@ driz_error_unset(struct driz_error_t *error) {
     assert(error);
 
     driz_error_init(error);
+}
+
+void
+py_warning(const char *format, ...) {
+    char warn_msg[MAX_DRIZ_ERROR_LEN];
+    va_list argp;
+    va_start(argp, format);
+    if (vsnprintf(warn_msg, MAX_DRIZ_ERROR_LEN, format, argp) < 1) {
+        strcpy(warn_msg, "Warning message formatting error.");
+    }
+    va_end(argp);
+
+    PyErr_WarnEx(PyExc_Warning, warn_msg, 1);
 }
 
 /*****************************************************************

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -38,6 +38,8 @@ const char *driz_error_get_message(struct driz_error_t *error);
 int driz_error_is_set(struct driz_error_t *error);
 void driz_error_unset(struct driz_error_t *error);
 
+void py_warning(const char *format, ...);
+
 /*****************************************************************
  CONVENIENCE MACROS
 */


### PR DESCRIPTION
This PR adds a warning about `pixfrac` being ignored when resampling with "lanczos" kernel when `pixfrac != 1`. Also fixes some comments in the code.