### PR TITLE
Replace 'scale' with two independent parameters: 'iscale' and 'kscale'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,13 @@ jobs:
         - linux: py310-xdist
         - linux: py311-xdist
         - linux: py312-xdist
+        - linux: py313-xdist
         # `tox` does not currently respect `requires-python` versions when creating testing environments;
         # if this breaks, add an upper pin to `requires-python` and revert this py3 to the latest working version
         - linux: py3-cov-xdist
           coverage: codecov
         - macos: py3-xdist
+          python-version: '>=3.13.5 <3.14'
         - windows: py3-xdist
           # exclude Python 1.13.4, see https://github.com/python/cpython/issues/135151
           python-version: '>=3.13.5 <3.14'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,15 +21,13 @@ Release Notes
   3rd-order kernel. Improved discrete approximation to the Lanczos
   kernel. [#198]
 
-<<<<<<< HEAD
 - Added support for propagating DQ bitfields from input images to the output
   image using bitwise-OR. [#206]
-=======
+
 - Argument ``scale`` of the ``add_image()`` method has been deprecated
   and split into two arguments: ``iscale`` that is multiplied with each input
   image before resampling and ``kscale`` used to compute appropriate
   resampling kernel size. [#203]
->>>>>>> 46a7b79 (Replace 'scale' with two independent parameters: 'iscale' and 'kscale')
 
 
 2.1.1 (2025-08-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,8 +21,15 @@ Release Notes
   3rd-order kernel. Improved discrete approximation to the Lanczos
   kernel. [#198]
 
+<<<<<<< HEAD
 - Added support for propagating DQ bitfields from input images to the output
   image using bitwise-OR. [#206]
+=======
+- Argument ``scale`` of the ``add_image()`` method has been deprecated
+  and split into two arguments: ``iscale`` that is multiplied with each input
+  image before resampling and ``kscale`` used to compute appropriate
+  resampling kernel size. [#203]
+>>>>>>> 46a7b79 (Replace 'scale' with two independent parameters: 'iscale' and 'kscale')
 
 
 2.1.1 (2025-08-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Release Notes
 =============
 
 
-2.2.0 (unreleased)
+3.0.0 (unreleased)
 ==================
 
 - Added support for resampling and co-adding images using squared weights.
@@ -16,18 +16,25 @@ Release Notes
   decreased accuracy of resampled image. Improved discrete approximation to
   the Lanczos kernel. [#198]
 
-- Fixed a bug in resampling using "blot" with Lanczos interpolation due to which
-  kernel window for 5th-order kernel was incorrectly set to the same as for
-  3rd-order kernel. Improved discrete approximation to the Lanczos
-  kernel. [#198]
+- Fixed a bug in resampling using "blot" with Lanczos interpolation due to
+  which kernel window for 5th-order kernel was incorrectly set to
+  the same as for 3rd-order kernel. Improved discrete approximation
+  to the Lanczos kernel. [#198]
+
+- Argument ``scale`` of the ``Resample.add_image()`` method has been deprecated
+  and split into two arguments: ``iscale`` that is multiplied with each input
+  image before resampling and ``pixel_scale_ratio`` used to compute appropriate
+  resampling kernel size. [#203]
+
+- In ``tblot``, the arguments ``pix_ratio``, ``exptime``, and
+  ``output_pixel_shape`` have been deprecated and will be removed in a future
+  release. Use ``iscale`` instead of the deprecated ``pix_ratio`` and
+  ``exptime``: ``iscale = exptime / pix_scale**2``. The argument
+  ``output_pixel_shape`` is not needed because the output image shape
+  can be inferred from ``pixmap``. [#203]
 
 - Added support for propagating DQ bitfields from input images to the output
   image using bitwise-OR. [#206]
-
-- Argument ``scale`` of the ``add_image()`` method has been deprecated
-  and split into two arguments: ``iscale`` that is multiplied with each input
-  image before resampling and ``kscale`` used to compute appropriate
-  resampling kernel size. [#203]
 
 
 2.1.1 (2025-08-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,11 @@ Release Notes
   release. Use ``iscale`` instead of the deprecated ``pix_ratio`` and
   ``exptime``: ``iscale = exptime / pix_scale**2``. The argument
   ``output_pixel_shape`` is not needed because the output image shape
-  can be inferred from ``pixmap``. [#203]
+  can be inferred from ``pixmap``. Also, argument ``misval`` has been renamed
+  to ``fillval`` (to match the name from ``tdriz``, ``Drizzle.resample``).
+
+- Added parameter ``out_img`` to ``blot_image`` to allow caller to pass their
+  own output image array. [#203]
 
 - Added support for propagating DQ bitfields from input images to the output
   image using bitwise-OR. [#206]

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -723,8 +723,9 @@ class Drizzle:
 
         iscale : float, optional
             It is a multiplicative factor used to rescale input image data
-            by ``iscale``. It may make sense to rescale input image by
-            squared pixel scale ratio (the linear dimension of a side of an
+            by ``iscale`` value. ``data2`` images will be rescaled by
+            ``iscale**2``. It may make sense to rescale input image (``data``)
+            by squared pixel scale ratio (the linear dimension of a side of an
             output pixel as seen in the input image's coordinate frame)
             depending on the units of the input image, i.e., counts vs
             brightness. For more details see section

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -982,7 +982,8 @@ class Drizzle:
 
 def blot_image(data, pixmap, pix_ratio=_DEPRECATED_ARG,
                exptime=_DEPRECATED_ARG, output_pixel_shape=_DEPRECATED_ARG,
-               iscale=1.0, interp='poly5', sinscl=1.0):
+               out_img=None, fillval=0.0, iscale=1.0, interp='poly5',
+               sinscl=1.0):
     """
     Resample the ``data`` input image onto an output grid defined by
     the ``pixmap`` array. ``blot_image`` performs resampling using one of
@@ -1042,6 +1043,14 @@ def blot_image(data, pixmap, pix_ratio=_DEPRECATED_ARG,
             Deprecated since version 3.0 and will be removed in a future
             release. It is not needed since the output image shape can be
             inferred from ``pixmap``.
+
+    output_image : 2D array of float32, None, optional
+        A 2D numpy array to hold the output image produced by resampling
+        the input image (``data``). If `None`, a new array will be allocated.
+
+    fillval: float, optional
+        The value of output pixels that did not have contributions from
+        input image' pixels.
 
     iscale : float, optional
         A multiplicative factor used to rescale output image data by
@@ -1105,10 +1114,17 @@ def blot_image(data, pixmap, pix_ratio=_DEPRECATED_ARG,
         )
         output_shape = output_pixel_shape[::-1]
 
-    out_img = np.zeros(output_shape, dtype=np.float32)
+    if out_img is None:
+        out_img = np.empty(output_shape, dtype=np.float32)
+    else:
+        out_img = np.asarray(out_img, dtype=np.float32)
+        if out_img.shape != output_shape:
+            raise ValueError(
+                "'output_image' shape is not consistent with 'pixmap' shape."
+            )
 
     cdrizzle.tblot(data, pixmap, out_img, iscale=iscale, interp=interp,
-                   misval=0.0, sinscl=sinscl)
+                   fillval=fillval, sinscl=sinscl)
 
     return out_img
 

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -22,6 +22,9 @@ SUPPORTED_DRIZZLE_KERNELS = [
 CTX_PLANE_BITS = 32
 
 
+_DEPRECATED_ARG = object()
+
+
 class Drizzle:
     """
     A class for managing resampling and co-adding of multiple images onto a
@@ -54,11 +57,52 @@ class Drizzle:
         method. If not, a copy of these arrays will be made when converting
         to the expected type (or expanding the context array).
 
+    Scaling of input image data
+    ---------------------------
+
+    It is important to highlight that the drizzle algorithm computes
+    *weighted mean* of input pixel values -- see equations (4) and (5) in
+    `Fruchter and Hook, PASP 2002 <https://doi.org/10.1086/338393>`_.
+    Therefore, it is important that all input pixel values that contribute
+    to an output pixel are from the same distribution. In other words,
+    input pixel values from different images must be on the same footing,
+    i.e., they must be comparable and must be representative of the same
+    physical quantity.
+
+    For example, for Hubble Space Telescope data, calibrated images
+    (i.e., ``*_flt.fits``, ``*_flc.fits``) are in unit of counts, counts per
+    second, electrons, or electrons per second. To convert them to flux
+    units (e.g., erg/cm^2/s/Angstrom), one needs to multiply these images
+    by the ``PHOTFLAM``. Sometimes, images that are drizzle-combined have been
+    observed at very different times (separated by many years) and the
+    sensitivity of the instrument (represented by ``PHOTFLAM``) may have
+    changed significantly. Other times a source is observed in different chips,
+    i.e., the two chips of the Wide Field Camera. In such cases detector's
+    sensitivity (``PHOTFLAM``) may be different for the images to be combined.
+    Consequently, pixel values in these images may not be directly comparable
+    and drizzle-combining such images would result in systematic errors.
+
+    In this case, it is important to rescale images to the same flux units
+    either by multiplying by the appropriate ``PHOTFLAM`` values or some
+    other appropriate scaling factor before combining them using drizzle.
+    This can be accomplished by using the ``iscale`` parameter of
+    :py:meth:`add_image` which simply multiplies each input image by
+    ``iscale``.
+
+    Also, for the case of HST images that have flux units instead of surface
+    brightness, if input images have different pixel scales, then the pixel
+    values must be rescaled by the square of the pixel scale ratio (the linear
+    dimension of a side of an output pixel as seen in the input image's
+    coordinate frame) in order to preserve flux. In this case ``iscale`` is
+    equivalent to ``s**2`` factor in equations (3) and (5) of
+    `Fruchter and Hook, PASP 2002 <https://doi.org/10.1086/338393>`_
+    (``s`` may be different for each input image).
+
     Output Science Image
     --------------------
 
-    Output science image is obtained by adding input pixel fluxes according to
-    equations (4) and (5) in
+    Output science image is obtained by computing *weighted mean* of input
+    pixel values according to equations (4) and (5) in
     `Fruchter and Hook, PASP 2002 <https://doi.org/10.1086/338393>`_.
     The weights and coefficients in those equations will depend on the chosen
     kernel, input image weights, and pixel overlaps computed from ``pixmap``.
@@ -132,6 +176,14 @@ class Drizzle:
 
     For convenience, this functionality was implemented in the
     :py:func:`~drizzle.utils.decode_context` function.
+
+    Output DQ Image
+    ---------------
+
+    If DQ array of input image pixels is provided via ``dq`` parameter of
+    :py:meth:`add_image`, then an output DQ array will be computed by combining
+    (using bitwise-OR) DQ bitfields of all input pixels that contribute to
+    a given output pixel.
 
     References
     ----------
@@ -602,9 +654,9 @@ class Drizzle:
         return plane_info
 
     def add_image(self, data, exptime, pixmap, data2=None, dq=None,
-                  iscale=1.0, kscale=1.0,
+                  scale=_DEPRECATED_ARG, iscale=1.0, pixel_scale_ratio=1.0,
                   weight_map=None, wht_scale=1.0, pixfrac=1.0, in_units='cps',
-                  xmin=None, xmax=None, ymin=None, ymax=None, **kwargs):
+                  xmin=None, xmax=None, ymin=None, ymax=None):
         """
         Resample and add an image to the cumulative output image. Also, update
         output total weight image and context images.
@@ -661,7 +713,7 @@ class Drizzle:
                 if you need it.
 
         scale : float, optional
-            Deprecated: use ``iscale`` and ``kscale`` instead.
+            Deprecated: use ``iscale`` and ``pixel_scale_ratio`` instead.
             It is a factor used both to rescale input image data
             by ``scale**2`` AND to compute the correct kernel size for some
             kernels ("turbo", "gaussian", and "lanczos"). It is recommended
@@ -675,17 +727,18 @@ class Drizzle:
             squared pixel scale ratio (the linear dimension of a side of an
             output pixel as seen in the input image's coordinate frame)
             depending on the units of the input image, i.e., counts vs
-            brightness.
+            brightness. For more details see section
+            "Scaling of input image data" in :py:class:`Drizzle`.
 
-        kscale : float, None, optional
+        pixel_scale_ratio : float, None, optional
             It is a factor used to compute the correct kernel size in output
             image's coordinate system for some of the kernels
             ("turbo", "gaussian", and "lanczos") from their nominal
             sizes in input image pixels. For example, for the "lanczos3"
             kernel, the nominal size is 3 input pixels. It is recommended that
-            ``kscale`` be set to pixel scale ratio: the linear dimension of
+            ``pixel_scale_ratio`` be set to pixel scale ratio: the linear dimension of
             output pixel relative to the size of an input pixel. When
-            ``kscale`` is `None`, it will be estimated from ``pixmap`` but this
+            ``pixel_scale_ratio`` is `None`, it will be estimated from ``pixmap`` but this
             can impose a performance penalty.
 
         weight_map : 2D array, None, optional
@@ -748,17 +801,16 @@ class Drizzle:
             ignored and did not contribute to the output image.
 
         """
-        scale = kwargs.pop('scale', None)
-        if scale is not None:
+        if scale is not _DEPRECATED_ARG:
             warnings.warn(
                 "Argument 'scale' has been deprecated since version 3.0 and "
                 "it will be removed in a future release. "
-                "Use 'iscale' and 'kscale' instead and set iscale=kscale**2 "
+                "Use 'iscale' and 'pixel_scale_ratio' instead and set iscale=pixel_scale_ratio**2 "
                 "to achieve the same effect as with 'scale'.",
                 DeprecationWarning
             )
             iscale = scale * scale
-            kscale = scale
+            pixel_scale_ratio = scale
 
         # this enables initializer to not need output image shape at all and
         # set output image shape based on output coordinates from the pixmap.
@@ -913,7 +965,7 @@ class Drizzle:
             ymax=ymax,
             iscale=iscale,  # scales image intensity. usually equal to 1 or
                             # (pixel scale ratio)**2
-            kscale=kscale,  # scales kernel size. usually equal to pixel scale ratio
+            pscale_ratio=pixel_scale_ratio,  # scales kernel size. usually equal to pixel scale ratio
             pixfrac=pixfrac,
             kernel=self._kernel,
             in_units=in_units,
@@ -928,8 +980,9 @@ class Drizzle:
         return nmiss, nskip
 
 
-def blot_image(data, pixmap, pix_ratio, exptime, output_pixel_shape,
-               interp='poly5', sinscl=1.0):
+def blot_image(data, pixmap, pix_ratio=_DEPRECATED_ARG,
+               exptime=_DEPRECATED_ARG, output_pixel_shape=_DEPRECATED_ARG,
+               iscale=1.0, interp='poly5', sinscl=1.0):
     """
     Resample the ``data`` input image onto an output grid defined by
     the ``pixmap`` array. ``blot_image`` performs resampling using one of
@@ -956,10 +1009,6 @@ def blot_image(data, pixmap, pix_ratio, exptime, output_pixel_shape,
         pixels in the ouput frame and ``pixmap[..., 1]`` forms a 2D array of
         Y-coordinates of input pixels in the ouput coordinate frame.
 
-    output_pixel_shape : tuple of int
-        A tuple of two integer numbers indicating the dimensions of the output
-        image ``(Nx, Ny)``.
-
     pix_ratio : float
         Ratio of the input image pixel scale to the output image pixel scale as
         used in the ``drizzle`` context: input is a distorted image that was
@@ -969,8 +1018,40 @@ def blot_image(data, pixmap, pix_ratio, exptime, output_pixel_shape,
         **It is used to scale the input image intensities to account
         for the change in pixel area.**
 
+        .. warning::
+            Deprecated since version 3.0 and will be removed in a future
+            release. Use ``iscale`` instead and set
+            ``iscale=1.0 / pix_ratio**2`` to achieve the same effect as with
+            ``pix_ratio``.
+
     exptime : float
-        The exposure time of the input image.
+        The exposure time of the input image. If provided it is used to scale
+        the output image values.
+
+        .. warning::
+            Deprecated since version 3.0 and will be removed in a future
+            release. Use ``iscale`` instead and set
+            ``iscale=exptime`` or ``exptime / pix_ratio**2`` to achieve the
+            same effect as with ``exptime`` (and ``pix_ratio``).
+
+    output_pixel_shape : tuple of int
+        A tuple of two integer numbers indicating the dimensions of the output
+        image ``(Nx, Ny)``.
+
+        .. warning::
+            Deprecated since version 3.0 and will be removed in a future
+            release. It is not needed since the output image shape can be
+            inferred from ``pixmap``.
+
+    iscale : float, optional
+        A multiplicative factor used to rescale output image data by
+        ``iscale``. Depending on specific needs, it may make sense to rescale
+        output image by inverse of squared pixel scale ratio (the linear
+        dimension of a side of a resampled/drizzled (input) pixel as seen in
+        the distorted (output) image's coordinate frame) depending on the units
+        of the input image, i.e., counts (flux) vs surface brightness.
+        For more details see section "Scaling of input image data" in
+        :py:class:`Drizzle`.
 
     interp : str, optional
         The type of interpolation used in the resampling. The
@@ -993,10 +1074,41 @@ def blot_image(data, pixmap, pix_ratio, exptime, output_pixel_shape,
         A 2D numpy array containing the resampled image data.
 
     """
-    out_img = np.zeros(output_pixel_shape[::-1], dtype=np.float32)
+    if pix_ratio is not _DEPRECATED_ARG:
+        warnings.warn(
+            "Argument 'pix_ratio' has been deprecated since version 3.0 and "
+            "it will be removed in a future release. "
+            "Use 'iscale' instead and set iscale=1.0 / pix_ratio**2 "
+            "to achieve the same effect as with 'pix_ratio'.",
+            DeprecationWarning
+        )
+        iscale /= pix_ratio * pix_ratio
 
-    cdrizzle.tblot(data, pixmap, out_img, iscale=pix_ratio**2, kscale=1.0,
-                   interp=interp, exptime=exptime, misval=0.0, sinscl=sinscl)
+    if exptime is not _DEPRECATED_ARG:
+        warnings.warn(
+            "Argument 'exptime' has been deprecated since version 3.0 and "
+            "it will be removed in a future release. "
+            "Use 'iscale' instead and set iscale=exptime "
+            "to achieve the same effect as with 'exptime'.",
+            DeprecationWarning
+        )
+        iscale *= exptime
+
+    if output_pixel_shape is _DEPRECATED_ARG:
+        output_shape = tuple(pixmap.shape[:2])
+    else:
+        warnings.warn(
+            "Argument 'output_pixel_shape' has been deprecated since version "
+            "3.0 and it will be removed in a future release. It is not needed "
+            "since the output image shape can be inferred from 'pixmap'.",
+            DeprecationWarning
+        )
+        output_shape = output_pixel_shape[::-1]
+
+    out_img = np.zeros(output_shape, dtype=np.float32)
+
+    cdrizzle.tblot(data, pixmap, out_img, iscale=iscale, interp=interp,
+                   misval=0.0, sinscl=sinscl)
 
     return out_img
 

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -364,7 +364,7 @@ def test_resample_kernel(tmpdir, kernel, test_image_type, max_diff_atol):
             pixmap=pixmap,
             weight_map=inwht,
             iscale=pscale_ratio**2,
-            kscale=pscale_ratio,
+            pixel_scale_ratio=pscale_ratio,
         )
     else:
         with pytest.warns(
@@ -377,7 +377,7 @@ def test_resample_kernel(tmpdir, kernel, test_image_type, max_diff_atol):
                 pixmap=pixmap,
                 weight_map=inwht,
                 iscale=pscale_ratio**2,
-                kscale=pscale_ratio,
+                pixel_scale_ratio=pscale_ratio,
             )
 
     _, med_diff, max_diff = centroid_statistics(
@@ -440,7 +440,7 @@ def test_resample_kernel_image(tmpdir, kernel, max_diff_atol):
         pixmap=pixmap,
         weight_map=inwht,
         iscale=pscale_ratio**2,
-        kscale=pscale_ratio,
+        pixel_scale_ratio=pscale_ratio,
     )
     outctx = driz.out_ctx[0]
 
@@ -576,9 +576,7 @@ def test_blot_interpolation(tmpdir, interpolator, test_image_type):
     blotted_image = resample.blot_image(
         outsci,
         pixmap=pixmap,
-        pix_ratio=pscale_ratio,
-        exptime=1.0,
-        output_pixel_shape=inwcs.pixel_shape,
+        iscale=1.0 / (pscale_ratio ** 2),
         **kwargs
     )
 
@@ -721,7 +719,7 @@ def test_context_agrees_with_weight():
 
 
 @pytest.mark.parametrize(
-    'kernel,fc,kscale',
+    'kernel,fc,pixel_scale_ratio',
     [
         ('square', True, 1.0),
         ('point', True, 1.0),
@@ -735,7 +733,7 @@ def test_context_agrees_with_weight():
         ('gaussian', False, None),
     ],
 )
-def test_flux_conservation_nondistorted(kernel, fc, kscale):
+def test_flux_conservation_nondistorted(kernel, fc, pixel_scale_ratio):
     n = 200
     in_shape = (n, n)
 
@@ -777,7 +775,7 @@ def test_flux_conservation_nondistorted(kernel, fc, kscale):
             out_wht,
             out_ctx,
             pixfrac=1.0,
-            kscale=kscale,
+            pscale_ratio=pixel_scale_ratio,
             kernel=kernel,
             in_units="cps",
             expscale=1.0,
@@ -796,7 +794,7 @@ def test_flux_conservation_nondistorted(kernel, fc, kscale):
                 out_wht,
                 out_ctx,
                 pixfrac=1.0,
-                kscale=kscale,
+                pscale_ratio=pixel_scale_ratio,
                 kernel=kernel,
                 in_units="cps",
                 expscale=1.0,
@@ -869,7 +867,7 @@ def test_flux_conservation_distorted(kernel, fc):
             out_wht,
             out_ctx,
             pixfrac=1.0,
-            kscale=1.0,
+            pscale_ratio=1.0,
             kernel=kernel,
             in_units="cps",
             expscale=1.0,
@@ -888,7 +886,7 @@ def test_flux_conservation_distorted(kernel, fc):
                 out_wht,
                 out_ctx,
                 pixfrac=1.0,
-                kscale=1.0,
+                pscale_ratio=1.0,
                 kernel=kernel,
                 in_units="cps",
                 expscale=1.0,
@@ -933,7 +931,7 @@ def test_flux_conservation_distorted_distributed_sources(nrcb5_stars, kernel, ps
         pixmap=pixmap,
         weight_map=inwht,
         iscale=1.0,
-        kscale=1.0,
+        pixel_scale_ratio=1.0,
     )
 
     # for efficiency, instead of doing this patch-by-patch,
@@ -953,7 +951,7 @@ def test_flux_conservation_distorted_distributed_sources(nrcb5_stars, kernel, ps
             pixmap=pixmap,
             weight_map=inwht,
             iscale=1.0,
-            kscale=1.0,
+            pixel_scale_ratio=1.0,
         )
         out_data = driz_var.out_img * driz_var.out_wht
     out_var = driz_var.out_img2[0] * (driz_var.out_wht**2)
@@ -1093,7 +1091,7 @@ def test_pixmap_shape_matches_image():
             pixmap=pixmap,
             weight_map=in_wht,
             iscale=1.0,
-            kscale=1.0,
+            pixel_scale_ratio=1.0,
         )
     assert str(err_info.value) == "'pixmap' shape is not consistent with 'data' shape."
 
@@ -1324,7 +1322,7 @@ def test_resample_edge_sgarea_bug():
         pixfrac=1.0,
         pixmap=pixmap,
         iscale=1.0,
-        kscale=1.0,
+        pixel_scale_ratio=1.0,
         wht_scale=1.0,
     )
     # expected pixels should be close to 42
@@ -1376,7 +1374,7 @@ def test_resample_edge_collinear():
         pixfrac=1.0,
         pixmap=pixmap,
         iscale=1.0,
-        kscale=1.0,
+        pixel_scale_ratio=1.0,
         wht_scale=1.0,
     )
 
@@ -1938,7 +1936,7 @@ def test_drizzle_var_identical_to_nonvar(kernel_fc, pscale_ratio, kscale_none):
             pixmap=pixmap,
             weight_map=inwht,
             iscale=pscale_ratio**2,
-            kscale=kscale,
+            pixel_scale_ratio=kscale,
             xmin=10,
             ymin=10,
             xmax=output_wcs.array_shape[0] - 10,
@@ -1951,7 +1949,7 @@ def test_drizzle_var_identical_to_nonvar(kernel_fc, pscale_ratio, kscale_none):
             pixmap=pixmap,
             weight_map=inwht,
             iscale=pscale_ratio**2,
-            kscale=kscale,
+            pixel_scale_ratio=kscale,
             xmin=10,
             ymin=10,
             xmax=output_wcs.array_shape[0] - 10,
@@ -1968,7 +1966,7 @@ def test_drizzle_var_identical_to_nonvar(kernel_fc, pscale_ratio, kscale_none):
                 pixmap=pixmap,
                 weight_map=inwht,
                 iscale=pscale_ratio**2,
-                kscale=kscale,
+                pixel_scale_ratio=kscale,
                 xmin=10,
                 ymin=10,
                 xmax=output_wcs.array_shape[0] - 10,
@@ -1986,7 +1984,7 @@ def test_drizzle_var_identical_to_nonvar(kernel_fc, pscale_ratio, kscale_none):
                 pixmap=pixmap,
                 weight_map=inwht,
                 iscale=pscale_ratio**2,
-                kscale=kscale,
+                pixel_scale_ratio=kscale,
                 xmin=10,
                 ymin=10,
                 xmax=output_wcs.array_shape[0] - 10,
@@ -2244,9 +2242,9 @@ def test_drizzle_dq_propagation_wrong_type():
 @pytest.mark.filterwarnings(
     r"ignore:Kernel '.*' is not a flux-conserving kernel:Warning"
 )
-def test_drizzle_ikscale_same_as_scale(kernel, pscale_ratio, use_var):
-    """ Test that the resampled science image using new "kscale" and "iscale"
-    parameters is identical to the resampled science image
+def test_drizzle_ipscale_same_as_scale(kernel, pscale_ratio, use_var):
+    """ Test that the resampled science image using new "pixel_scale_ratio" and
+    "iscale" parameters is identical to the resampled science image
     using the old "scale" parameter.
 
     TODO: remove this test when support for "scale" is removed.
@@ -2292,7 +2290,7 @@ def test_drizzle_ikscale_same_as_scale(kernel, pscale_ratio, use_var):
         pixmap=pixmap,
         weight_map=inwht,
         iscale=pscale_ratio**2,
-        kscale=pscale_ratio,
+        pixel_scale_ratio=pscale_ratio,
         xmin=10,
         ymin=10,
         xmax=output_wcs.array_shape[0] - 10,

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -23,27 +23,6 @@
 static PyObject *gl_Error;
 FILE *driz_log_handle = NULL;
 
-/** ---------------------------------------------------------------------------
- * Multiply each pixel in an image by a scale factor
- */
-
-static void
-scale_image(PyArrayObject *image, double scale_factor) {
-    long i, size;
-    float *imptr;
-
-    assert(image);
-    imptr = (float *)PyArray_DATA(image);
-
-    size = PyArray_DIMS(image)[0] * PyArray_DIMS(image)[1];
-
-    for (i = size; i > 0; --i) {
-        *imptr++ *= scale_factor;
-    }
-
-    return;
-}
-
 static int
 process_array_list(PyObject *list, integer_t *nx, integer_t *ny,
                    const char *name, PyArrayObject ***arrays, int *nmax,
@@ -588,15 +567,16 @@ tdriz(PyObject *self, PyObject *args, PyObject *keywords) {
 
     /* If the input image is not in CPS we need to divide by the exposure */
     if (inun != unit_cps) {
-        inv_exposure_time = 1.0f / expin;
-        scale_image(img, inv_exposure_time);
-        if (img2_list) {
-            for (i = 0; i < nsq_arr; ++i) {
-                if (img2_list[i] != NULL) {
-                    scale_image(img2_list[i], pow(inv_exposure_time, 2.0));
-                }
-            }
-        }
+        iscale /= expin;
+        // inv_exposure_time = 1.0f / expin;
+        // scale_image(img, inv_exposure_time);
+        // if (img2_list) {
+        //     for (i = 0; i < nsq_arr; ++i) {
+        //         if (img2_list[i] != NULL) {
+        //             scale_image(img2_list[i], pow(inv_exposure_time, 2.0));
+        //         }
+        //     }
+        // }
     }
 
     /* Setup reasonable defaults for drizzling */

--- a/src/cdrizzleblot.c
+++ b/src/cdrizzleblot.c
@@ -909,7 +909,6 @@ doblot(struct driz_param_t *p) {
         lanczos.nbox = (integer_t)order;
         lanczos.nlut = nlut;
         lanczos.space = lut_delta;
-        lanczos.misval = p->misval;
 
         state = &lanczos;
 
@@ -976,7 +975,7 @@ doblot(struct driz_param_t *p) {
                         p->error, "OOB in output_data[%d,%d]", i, j);
                     return 1;
                 } else {
-                    set_pixel(p->output_data, i, j, p->misval);
+                    set_pixel(p->output_data, i, j, p->fill_value);
                     p->nmiss++;
                 }
             }

--- a/src/cdrizzleblot.c
+++ b/src/cdrizzleblot.c
@@ -940,10 +940,10 @@ doblot(struct driz_param_t *p) {
                 driz_error_format_message(p->error, "OOB in pixmap[%d,%d]", i,
                                           j);
                 return 1;
-            } else {
-                xo = (float)get_pixmap(p->pixmap, i, j)[0];
-                yo = (float)get_pixmap(p->pixmap, i, j)[1];
             }
+
+            xo = (float)get_pixmap(p->pixmap, i, j)[0];
+            yo = (float)get_pixmap(p->pixmap, i, j)[1];
 
             if (npy_isnan(xo) || npy_isnan(yo)) {
                 driz_error_format_message(p->error, "NaN in pixmap[%d,%d]", i,
@@ -970,14 +970,8 @@ doblot(struct driz_param_t *p) {
             } else {
                 /* If there is nothing for us then set the output to missing C
                    value flag */
-                if (oob_pixel(p->output_data, i, j)) {
-                    driz_error_format_message(
-                        p->error, "OOB in output_data[%d,%d]", i, j);
-                    return 1;
-                } else {
-                    set_pixel(p->output_data, i, j, p->fill_value);
-                    p->nmiss++;
-                }
+                set_pixel(p->output_data, i, j, p->fill_value);
+                p->nmiss++;
             }
         }
     }

--- a/src/cdrizzleblot.c
+++ b/src/cdrizzleblot.c
@@ -870,7 +870,7 @@ doblot(struct driz_param_t *p) {
     int order;
     size_t nlut;
     integer_t isize[2], osize[2];
-    float scale2, xo, yo, v;
+    float xo, yo, v;
     integer_t i, j;
     interp_function *interpolate;
     struct sinc_param_t sinc;
@@ -904,7 +904,7 @@ doblot(struct driz_param_t *p) {
 
         create_lanczos_lut(order, nlut, lut_delta, lanczos.lut);
 
-        lanczos.nbox = (integer_t)(order / p->kscale);
+        lanczos.nbox = (integer_t)((float)order / p->kscale);
         lanczos.nlut = nlut;
         lanczos.space = lut_delta;
         lanczos.misval = p->misval;
@@ -930,8 +930,6 @@ doblot(struct driz_param_t *p) {
        correction to separate the distortion-induced scale change.
     */
 
-    /* Recalculate the area scaling factor */
-    scale2 = p->scale * p->scale;
     v = 1.0;
 
     for (j = 0; j < osize[1]; ++j) {
@@ -962,7 +960,7 @@ doblot(struct driz_param_t *p) {
                     goto doblot_exit_;
                 }
 
-                value = v * p->ef / scale2;
+                value = v * p->ef / p->iscale;
                 if (oob_pixel(p->output_data, i, j)) {
                     driz_error_format_message(
                         p->error, "OOB in output_data[%d,%d]", i, j);

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -548,7 +548,7 @@ do_kernel_point_var(struct driz_param_t *p) {
     struct scanner s;
     integer_t i, j, ii, jj, k;
     integer_t osize[2];
-    float iscale2, d, dow, *d2 = NULL;
+    float d, dow, *d2 = NULL, iscale2 = 1.0f;
     integer_t bv;
     int xmin, xmax, ymin, ymax, n, ndata2;
     unsigned int dqval = 0;
@@ -682,7 +682,7 @@ do_kernel_gaussian_var(struct driz_param_t *p) {
     struct scanner s;
     integer_t bv, i, j, ii, jj, k, nxi, nxa, nyi, nya, nhit;
     integer_t osize[2];
-    float d, dow, *d2 = NULL, iscale2;
+    float d, dow, *d2 = NULL, iscale2 = 1.0f;
     double gaussian_efac, gaussian_es;
     double pfo, ac, w, ddx, ddy, r2, dover, kscale2;
     const double nsig = 2.5;
@@ -863,7 +863,7 @@ do_kernel_lanczos_var(struct driz_param_t *p) {
     struct scanner s;
     integer_t bv, i, j, ii, jj, k, nxi, nxa, nyi, nya, nhit;
     integer_t osize[2];
-    float iscale2, d, dow, *d2 = NULL;
+    float d, dow, *d2 = NULL, iscale2 = 1.0f;
     double pfo, xx, yy, w, dover;
     int kernel_order;
     size_t nlut;
@@ -1062,7 +1062,7 @@ do_kernel_turbo_var(struct driz_param_t *p) {
     struct scanner s;
     integer_t bv, i, j, ii, jj, k, nhit, iis, iie, jjs, jje;
     integer_t osize[2];
-    float d, dow, *d2 = NULL, iscale2;
+    float d, dow, *d2 = NULL, iscale2 = 1.0f;
     double pfo, dover_scale, ac;
     double xxi, xxa, yyi, yya, w, dover;
     int xmin, xmax, ymin, ymax, n, ndata2;
@@ -1240,7 +1240,7 @@ int
 do_kernel_square_var(struct driz_param_t *p) {
     integer_t bv, i, j, ii, jj, k, min_ii, max_ii, min_jj, max_jj, nhit;
     integer_t osize[2], mapsize[2];
-    float iscale2, d, dow, *d2 = NULL;
+    float d, dow, *d2 = NULL, iscale2 = 1.0f;
     double dh, jaco, dover, w;
 
     double xin[4], yin[4], xout[4], yout[4];

--- a/src/cdrizzlebox.h
+++ b/src/cdrizzlebox.h
@@ -25,8 +25,8 @@ integer_t compute_bit_value(integer_t uuid);
 int dobox(struct driz_param_t *p);
 
 double compute_area(double is, double js, const double x[4], const double y[4]);
-int compute_kscale(struct driz_param_t *p, struct polygon *bounding_polygon,
-                   float *kscale);
+int compute_pscale_ratio(struct driz_param_t *p,
+                         struct polygon *bounding_polygon, float *pscale_ratio);
 
 double boxer(double is, double js, const double x[4], const double y[4]);
 

--- a/src/cdrizzlebox.h
+++ b/src/cdrizzlebox.h
@@ -1,6 +1,7 @@
 #ifndef CDRIZZLEBOX_H
 #define CDRIZZLEBOX_H
 
+#include "cdrizzlemap.h"
 #include "cdrizzleutil.h"
 
 /**

--- a/src/cdrizzlebox.h
+++ b/src/cdrizzlebox.h
@@ -24,6 +24,8 @@ integer_t compute_bit_value(integer_t uuid);
 int dobox(struct driz_param_t *p);
 
 double compute_area(double is, double js, const double x[4], const double y[4]);
+int compute_kscale(struct driz_param_t *p, struct polygon *bounding_polygon,
+                   float *kscale);
 
 double boxer(double is, double js, const double x[4], const double y[4]);
 

--- a/src/cdrizzlemap.h
+++ b/src/cdrizzlemap.h
@@ -93,6 +93,8 @@ struct scanner {
     //                  driz_param_t.
     int overlap_valid; /**< 1 if x/y min/max updated from polygon intersection
                           and 0 if carried over from driz_param_t */
+    struct polygon bounding_polygon; /**< bounding polygon in input image
+                                        outlining the scan region */
 };
 
 int interpolate_point(struct driz_param_t *par, double xin, double yin,
@@ -124,5 +126,7 @@ int get_scanline_limits(struct scanner *s, int y, int *x1, int *x2);
 
 int init_image_scanner(struct driz_param_t *par, struct scanner *s, int *ymin,
                        int *ymax);
+
+int polygon_centroid(const struct polygon *p, double *cx, double *cy);
 
 #endif /* CDRIZZLEMAP_H */

--- a/src/cdrizzleutil.c
+++ b/src/cdrizzleutil.c
@@ -139,7 +139,7 @@ driz_param_dump(struct driz_param_t *p) {
     printf("  in_units:        %s\n", unit_enum2str(p->in_units));
     printf("  out_units:       %s\n", unit_enum2str(p->out_units));
     printf("  iscale:          %f\n", p->iscale);
-    printf("  kscale:          %f\n", p->kscale);
+    printf("  pscale_ratio:    %f\n", p->pscale_ratio);
 }
 
 void
@@ -167,7 +167,7 @@ driz_param_init(struct driz_param_t *p) {
     p->out_units = unit_counts;
 
     p->iscale = 1.0f;
-    p->kscale = NPY_NANF; /* Scaling for kernel size. NaN */
+    p->pscale_ratio = NPY_NANF; /* Scaling for kernel size. NaN */
 
     /* Input data */
     p->data = NULL;

--- a/src/cdrizzleutil.c
+++ b/src/cdrizzleutil.c
@@ -40,7 +40,8 @@ driz_error_set_message(struct driz_error_t *error, const char *message) {
     assert(error);
     assert(message);
 
-    strncpy(error->last_message, message, MAX_DRIZ_ERROR_LEN);
+    strncpy(error->last_message, message, MAX_DRIZ_ERROR_LEN - 1);
+    error->last_message[MAX_DRIZ_ERROR_LEN - 1] = '\0';
 }
 
 void
@@ -54,8 +55,9 @@ driz_error_format_message(struct driz_error_t *error, const char *format, ...) {
     assert(format);
 
     va_start(argp, format);
-    (void)vsnprintf(error->last_message, MAX_DRIZ_ERROR_LEN, format, argp);
+    (void)vsnprintf(error->last_message, MAX_DRIZ_ERROR_LEN - 1, format, argp);
     va_end(argp);
+    error->last_message[MAX_DRIZ_ERROR_LEN - 1] = '\0';
 }
 
 void
@@ -70,9 +72,10 @@ driz_error_set(struct driz_error_t *error, PyObject *type, const char *format,
     assert(format);
 
     va_start(argp, format);
-    (void)vsnprintf(error->last_message, MAX_DRIZ_ERROR_LEN, format, argp);
+    (void)vsnprintf(error->last_message, MAX_DRIZ_ERROR_LEN - 1, format, argp);
     va_end(argp);
 
+    error->last_message[MAX_DRIZ_ERROR_LEN - 1] = '\0';
     error->type = type;
 }
 
@@ -102,14 +105,17 @@ py_warning(PyObject *warning_type, const char *format, ...) {
     char warn_msg[MAX_DRIZ_ERROR_LEN];
     va_list argp;
     va_start(argp, format);
-    if (vsnprintf(warn_msg, MAX_DRIZ_ERROR_LEN, format, argp) < 1) {
-        strcpy(warn_msg, "Warning message formatting error.");
+    if (vsnprintf(warn_msg, MAX_DRIZ_ERROR_LEN - 1, format, argp) < 1) {
+        strncpy(warn_msg, "Warning message formatting error.",
+                MAX_DRIZ_ERROR_LEN - 1);
     }
     va_end(argp);
 
     if (!warning_type) {
         warning_type = PyExc_Warning;
     }
+
+    warn_msg[MAX_DRIZ_ERROR_LEN - 1] = '\0';
 
     PyErr_WarnEx(warning_type, warn_msg, 1);
 }
@@ -121,23 +127,19 @@ void
 driz_param_dump(struct driz_param_t *p) {
     assert(p);
 
-    printf(
-        "DRIZZLING PARAMETERS:\n"
-        "kernel:          %s\n"
-        "pixel_fraction:  %f\n"
-        "exposure_time:   %f\n"
-        "weight_scale:    %f\n"
-        "fill_value:      %f\n"
-        "fill_value2:     %f\n"
-        "do_fill:         %s\n"
-        "do_fill2:        %s\n"
-        "in_units:        %s\n"
-        "out_units:       %s\n"
-        "iscale:          %f\n",
-        "kscale:          %f\n", kernel_enum2str(p->kernel), p->pixel_fraction,
-        p->exposure_time, p->weight_scale, p->fill_value, p->fill_value2,
-        bool2str(p->do_fill), bool2str(p->do_fill2), unit_enum2str(p->in_units),
-        unit_enum2str(p->out_units), p->iscale, p->kscale);
+    printf("DRIZZLING PARAMETERS:\n");
+    printf("  kernel:          %s\n", kernel_enum2str(p->kernel));
+    printf("  pixel_fraction:  %f\n", p->pixel_fraction);
+    printf("  exposure_time:   %f\n", p->exposure_time);
+    printf("  weight_scale:    %f\n", p->weight_scale);
+    printf("  fill_value:      %f\n", p->fill_value);
+    printf("  fill_value2:     %f\n", p->fill_value2);
+    printf("  do_fill:         %s\n", bool2str(p->do_fill));
+    printf("  do_fill2:        %s\n", bool2str(p->do_fill2));
+    printf("  in_units:        %s\n", unit_enum2str(p->in_units));
+    printf("  out_units:       %s\n", unit_enum2str(p->out_units));
+    printf("  iscale:          %f\n", p->iscale);
+    printf("  kscale:          %f\n", p->kscale);
 }
 
 void

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -38,7 +38,7 @@ const char *driz_error_get_message(struct driz_error_t *error);
 int driz_error_is_set(struct driz_error_t *error);
 void driz_error_unset(struct driz_error_t *error);
 
-void py_warning(const char *format, ...);
+void py_warning(PyObject *warning_type, const char *format, ...);
 
 /*****************************************************************
  CONVENIENCE MACROS
@@ -136,7 +136,9 @@ struct driz_param_t {
     integer_t out_ny;
 
     /* Scaling */
-    double scale;
+    float iscale;
+    float kscale; /* Scaling for kernel size. 0 or negative means it will be
+                     estimated from pixmap for t*/
 
     /* Image subset */
     integer_t xmin;
@@ -149,7 +151,6 @@ struct driz_param_t {
     float ef;
     float misval;
     float sinscl;
-    float kscale;
 
     /* Input images */
     PyArrayObject *data;

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -38,7 +38,7 @@ const char *driz_error_get_message(struct driz_error_t *error);
 int driz_error_is_set(struct driz_error_t *error);
 void driz_error_unset(struct driz_error_t *error);
 
-void py_warning(PyObject *warning_type, const char *format, ...);
+int py_warning(PyObject *warning_type, const char *format, ...);
 
 /*****************************************************************
  CONVENIENCE MACROS

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -137,8 +137,8 @@ struct driz_param_t {
 
     /* Scaling */
     float iscale;
-    float kscale; /* Scaling for kernel size. 0 or negative means it will be
-                     estimated from pixmap for t*/
+    float pscale_ratio; /* Scaling used for kernel size in tdriz. 0 or negative
+                     means it will be estimated from pixmap for t*/
 
     /* Image subset */
     integer_t xmin;

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -110,22 +110,21 @@ struct lanczos_param_t {
     double sdp;
     integer_t nbox;
     double space;
-    float misval;
 };
 
 struct driz_param_t {
     /* Options */
-    enum e_kernel_t kernel;  /* Kernel shape and size */
-    double pixel_fraction;   /* was: PIXFRAC */
-    float exposure_time;     /* Exposure time was: EXPIN */
-    float weight_scale;      /* Weight scale was: WTSCL */
-    float fill_value;        /* Filling was: FILVAL */
-    float fill_value2;       /* Filling was: FILVAL */
-    bool_t do_fill;          /* was: FILL */
-    bool_t do_fill2;         /* was: FILL */
-    enum e_unit_t in_units;  /* CPS / counts was: INCPS, either counts or CPS */
-    enum e_unit_t out_units; /* CPS / counts was: INCPS, either counts or CPS */
-    integer_t uuid;          /* was: UNIQID */
+    enum e_kernel_t kernel;
+    double pixel_fraction;
+    float exposure_time;
+    float weight_scale;
+    float fill_value;
+    float fill_value2;
+    bool_t do_fill;
+    bool_t do_fill2;
+    enum e_unit_t in_units;
+    enum e_unit_t out_units;
+    integer_t uuid;
 
     /* Input image dimensions */
     integer_t in_nx;

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -72,7 +72,7 @@ init_pixmap(struct driz_param_t *p) {
 }
 
 void
-stretch_pixmap(struct driz_param_t *p, double stretch) {
+stretch_pixmap(struct driz_param_t *p, double sx, double sy) {
     int i, j;
     double xpix, ypix;
 
@@ -80,8 +80,8 @@ stretch_pixmap(struct driz_param_t *p, double stretch) {
     for (j = 0; j < image_size[1]; j++) {
         xpix = 0.0;
         for (i = 0; i < image_size[0]; i++) {
-            get_pixmap(p->pixmap, i, j)[0] = xpix;
-            get_pixmap(p->pixmap, i, j)[1] = stretch * ypix;
+            get_pixmap(p->pixmap, i, j)[0] = sx * xpix;
+            get_pixmap(p->pixmap, i, j)[1] = sy * ypix;
             xpix += 1.0;
         }
         ypix += 1.0;
@@ -259,7 +259,8 @@ setup_parameters(void) {
     p->xmax = image_size[0] - 1;
     p->ymin = 0;
     p->ymax = image_size[1] - 1;
-    p->scale = 1.0;
+    p->iscale = 1.0f;
+    p->kscale = 1.0f;
     p->pixel_fraction = 1.0;
     p->exposure_time = 1.0;
     p->ef = p->exposure_time;
@@ -350,7 +351,7 @@ FCT_BGN_FN(utest_cdrizzle) {
         FCT_TEST_BGN(utest_map_lookup_01) {
             struct driz_param_t *p;
             p = setup_parameters();
-            stretch_pixmap(p, 1000.0);
+            stretch_pixmap(p, 1.0, 1000.0);
 
             double x = get_pixmap(p->pixmap, 1, 1)[0];
             double y = get_pixmap(p->pixmap, 1, 1)[1];
@@ -365,7 +366,7 @@ FCT_BGN_FN(utest_cdrizzle) {
         FCT_TEST_BGN(utest_map_lookup_02) {
             struct driz_param_t *p;
             p = setup_parameters();
-            stretch_pixmap(p, 1000.0);
+            stretch_pixmap(p, 1.0, 1000.0);
 
             double x = get_pixmap(p->pixmap, 3, 0)[0];
             double y = get_pixmap(p->pixmap, 3, 0)[1];
@@ -380,7 +381,7 @@ FCT_BGN_FN(utest_cdrizzle) {
         FCT_TEST_BGN(utest_map_lookup_03) {
             struct driz_param_t *p;
             p = setup_parameters();
-            stretch_pixmap(p, 1000.0);
+            stretch_pixmap(p, 1.0, 1000.0);
 
             double x = get_pixmap(p->pixmap, 0, 1)[0];
             double y = get_pixmap(p->pixmap, 0, 1)[1];
@@ -394,7 +395,7 @@ FCT_BGN_FN(utest_cdrizzle) {
         FCT_TEST_BGN(utest_map_lookup_04) {
             struct driz_param_t *p;
             p = setup_parameters();
-            stretch_pixmap(p, 1000.0);
+            stretch_pixmap(p, 1.0, 1000.0);
 
             double x = get_pixmap(p->pixmap, 3, 1)[0];
             double y = get_pixmap(p->pixmap, 3, 1)[1];
@@ -405,12 +406,42 @@ FCT_BGN_FN(utest_cdrizzle) {
         }
         FCT_TEST_END();
 
+        FCT_TEST_BGN(utest_compute_kscale) {
+            struct driz_param_t *p;
+            struct polygon bp;
+            float kscale;
+            const float kscale_truth = sqrtf(1.2f * 1.7f);
+
+            p = setup_parameters();
+            stretch_pixmap(p, 1.2, 1.7);
+            bp.npv = 4;
+            bp.v[0].x = 0.0;
+            bp.v[0].y = 0.0;
+            bp.v[1].x = (double)p->xmax;
+            bp.v[1].y = 0.0;
+            bp.v[2].x = (double)p->xmax;
+            bp.v[2].y = (double)p->ymax;
+            bp.v[2].x = 0.0;
+            bp.v[2].y = (double)p->ymax;
+
+            compute_kscale(p, &bp, &kscale);
+
+            fct_xchk(
+                (int)(fabs(kscale - kscale_truth) < 5.0f * FLT_EPSILON),
+                "chk_eq_flt: %f != %f",
+                kscale,
+                kscale_truth);
+
+            teardown_parameters(p);
+        }
+        FCT_TEST_END();
+
         FCT_TEST_BGN(utest_map_point_01) {
             double ix, iy, ox, oy;
             struct driz_param_t *p;
 
             p = setup_parameters();
-            stretch_pixmap(p, 1000.0);
+            stretch_pixmap(p, 1.0, 1000.0);
 
             ix = 2.5;
             iy = 1.5;
@@ -429,7 +460,7 @@ FCT_BGN_FN(utest_cdrizzle) {
             struct driz_param_t *p;
 
             p = setup_parameters();
-            stretch_pixmap(p, 1000.0);
+            stretch_pixmap(p, 1.0, 1000.0);
 
             ix = -1.0;
             iy = 0.5;
@@ -449,7 +480,7 @@ FCT_BGN_FN(utest_cdrizzle) {
             struct driz_param_t *p;
 
             p = setup_parameters();
-            stretch_pixmap(p, 1000.0);
+            stretch_pixmap(p, 1.0, 1000.0);
 
             ix = 3.25;
             iy = 5.0;
@@ -478,7 +509,7 @@ FCT_BGN_FN(utest_cdrizzle) {
 
             p = setup_parameters();
 
-            stretch_pixmap(p, 1000.0);
+            stretch_pixmap(p, 1.0, 1000.0);
 
             ix = 0.25;
             iy = 5.0;

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -260,7 +260,7 @@ setup_parameters(void) {
     p->ymin = 0;
     p->ymax = image_size[1] - 1;
     p->iscale = 1.0f;
-    p->kscale = 1.0f;
+    p->pscale_ratio = 1.0f;
     p->pixel_fraction = 1.0;
     p->exposure_time = 1.0;
     p->ef = p->exposure_time;
@@ -406,11 +406,11 @@ FCT_BGN_FN(utest_cdrizzle) {
         }
         FCT_TEST_END();
 
-        FCT_TEST_BGN(utest_compute_kscale) {
+        FCT_TEST_BGN(utest_compute_pscale_ratio) {
             struct driz_param_t *p;
             struct polygon bp;
-            float kscale;
-            const float kscale_truth = sqrtf(1.2f * 1.7f);
+            float pscale_ratio;
+            const float pscale_ratio_truth = sqrtf(1.2f * 1.7f);
 
             p = setup_parameters();
             stretch_pixmap(p, 1.2, 1.7);
@@ -424,13 +424,13 @@ FCT_BGN_FN(utest_cdrizzle) {
             bp.v[2].x = 0.0;
             bp.v[2].y = (double)p->ymax;
 
-            compute_kscale(p, &bp, &kscale);
+            compute_pscale_ratio(p, &bp, &pscale_ratio);
 
             fct_xchk(
-                (int)(fabs(kscale - kscale_truth) < 5.0f * FLT_EPSILON),
+                (int)(fabs(pscale_ratio - pscale_ratio_truth) < 5.0f * FLT_EPSILON),
                 "chk_eq_flt: %f != %f",
-                kscale,
-                kscale_truth);
+                pscale_ratio,
+                pscale_ratio_truth);
 
             teardown_parameters(p);
         }


### PR DESCRIPTION
This PR deprecates parameter `scale` of `Drizzle.add_image()` method. This parameter has the meaning of pixel scale ratio and it was carried over from `drizzlepac` where it is used to do two separate things:
- to rescale input image by `scale**2` because there `PHOTFLAM` of the resampled image -- conversion factor used to convert count rate to flux units -- was not rescaled (and left equal to that of the first input image);
- to rescale resample kernels to the correct size.

These are two different and independent issues and having a single `scale` parameter is just incorrect for a wide range of cases. For example, in JWST, pixel values are surface brightness and converting to flux is achieved by multiplying them by pixel area which is modified for the output image (basically `PHOTFLAM` equivalent is modified) and so a `scale=1` is what is used there. However, this leads to incorrect kernel size, see, e.g., https://github.com/spacetelescope/stcal/pull/412

Splitting `scale` into two independent parameters will allow us to correctly handle various situations/needs.