### PR TITLE
AL-982: Add support for propagation of DQ flags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ Release Notes
   3rd-order kernel. Improved discrete approximation to the Lanczos
   kernel. [#198]
 
+- Added support for propagating DQ bitfields from input images to the output
+  image using bitwise-OR. [#206]
+
 
 2.1.1 (2025-08-14)
 ==================

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -340,6 +340,7 @@ class Drizzle:
         if out_dq is not None:
             out_dq = np.asarray(out_dq, dtype=np.int32)
             shapes.add(out_dq.shape)
+            self._out_dq = out_dq
 
         if out_shape is not None:
             shapes.add(tuple(out_shape))
@@ -384,14 +385,6 @@ class Drizzle:
                 )
         self._output_shapes = shapes
         self._alloc_output_arrays2_init(out_img2=out_img2)
-
-        if out_dq is not None:
-            out_dq = np.asarray(out_dq, dtype=np.int32)
-            if out_dq.shape != self._out_shape:
-                raise ValueError(
-                    "'out_dq' must have the same shape as 'out_img'."
-                )
-            self._out_dq = out_dq
 
     @property
     def fillval(self):

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -45,7 +45,8 @@ class Drizzle:
         the class initializer can allocate these arrays based on other input
         parameters such as ``output_shape``. If caller-supplied output arrays
         have the correct type (`numpy.float32` for ``out_img``, ``out_img2``
-        and ``out_wht`` and `numpy.int32` for the ``out_ctx`` array) and if
+        and ``out_wht``, `numpy.int32` for the ``out_ctx`` array and
+        `numpy.uint32` for the ``out_dq`` array) and if
         ``out_ctx`` is large enough not to need to be resized, these arrays
         will be used as is and may be modified by the :py:meth:`add_image`
         method. If not, a copy of these arrays will be made when converting
@@ -232,17 +233,23 @@ class Drizzle:
             Subsequent calls hold intermediate results. This parameter is
             ignored when ``disable_ctx`` is `True`.
 
-        out_dq : 2D array of int32, None, optional
+        out_dq : 2D array of uint32, None, optional
             A 2D `~numpy.ndarray` containing DQ bitfields of output (resampled)
-            pixels. It is computed by combining (using bitwise-OR) DQ bitfields
-            of input pixels that contributed to the output pixel.
+            pixels. It will be computed by combining (using bitwise-OR)
+            DQ bitfields of input pixels that contributed to the output pixel.
             If provided, it must be a 2D array of the same shape as
-            ``out_img``. If `None`, output DQ array will be created during
+            ``out_img`` and `numpy.uint32` type (unsigned 32-bit integer type).
+            If `None`, output DQ array will be created during
             the first call to `add_image` and will be initialized to zero.
+
+            .. warning::
+                64-bit integer type is not supported and will raise
+                an exception. Contact the authors to add support for 64-bit DQ
+                if you need it.
 
         exptime : float, optional
             Exposure time of previously resampled images when provided via
-            parameters ``out_img``, ``out_wht``, ``out_ctx``.
+            parameters ``out_img`` and ``out_wht``.
 
         begin_ctx_id : int, optional
             The context ID number (0-based) of the first image that will be
@@ -338,7 +345,13 @@ class Drizzle:
             shapes.add(out_ctx.shape[1:])
 
         if out_dq is not None:
-            out_dq = np.asarray(out_dq, dtype=np.int32)
+            t = np.min_scalar_type(out_dq)
+            if t.kind not in ['i', 'u'] or t.itemsize > 4:
+                raise TypeError(
+                    "'out_dq' must be of an unsigned integer type with "
+                    "itemsize of 4 bytes or less."
+                )
+            out_dq = np.asarray(out_dq, dtype=np.uint32)
             shapes.add(out_dq.shape)
             self._out_dq = out_dq
 
@@ -631,12 +644,18 @@ class Drizzle:
                 to rate units before resampling.
 
         dq : 2D array, None, optional
-            A 2D numpy array containing DQ bitfields of input pixels. It must
+            A 2D numpy array of type `numpy.uint32` (unsigned 32-bit integer
+            type) containing DQ bitfields of input pixels. It must
             have the same shape as ``data``. If provided, output DQ array
             (accessible via ``out_dq`` property) will be computed by combining
             (using bitwise-OR) DQ bitfields of input pixels that contributed to
             the output pixel. If `None`, DQ array of the output image will
             not be computed.
+
+            .. warning::
+                64-bit integer type is not supported and will raise
+                an exception. Contact the authors to add support for 64-bit DQ
+                if you need it.
 
         scale : float, optional
             The pixel scale of the input image. Conceptually, this is the
@@ -818,13 +837,19 @@ class Drizzle:
             ctx_plane = self._out_ctx[plane_no]
 
         if dq is not None:
-            dq = np.asarray(dq, dtype=np.int32)
+            t = np.min_scalar_type(dq)
+            if t.kind not in ['i', 'u'] or t.itemsize > 4:
+                raise TypeError(
+                    "'dq' must be of an unsigned integer type with itemsize "
+                    "of 4 bytes or less."
+                )
+            dq = np.asarray(dq, dtype=np.uint32)
             if dq.shape != data.shape:
                 raise ValueError(
                     "'dq' shape is not consistent with 'data' shape."
                 )
             if self._out_dq is None:
-                self._out_dq = np.zeros(self._out_shape, dtype=np.int32)
+                self._out_dq = np.zeros(self._out_shape, dtype=np.uint32)
 
         # TODO: probably tdriz should be modified to not return version.
         #       we should not have git, Python, C, ... versions

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -167,8 +167,8 @@ class Drizzle:
 
     def __init__(self, kernel="square", fillval=None, fillval2=None,
                  out_shape=None, out_img=None, out_wht=None, out_ctx=None,
-                 out_img2=None, exptime=0.0, begin_ctx_id=0, max_ctx_id=None,
-                 disable_ctx=False):
+                 out_img2=None, out_dq=None, exptime=0.0, begin_ctx_id=0,
+                 max_ctx_id=None, disable_ctx=False):
         """
         kernel: str, optional
             The name of the kernel used to combine the input. The choice of
@@ -232,6 +232,14 @@ class Drizzle:
             Subsequent calls hold intermediate results. This parameter is
             ignored when ``disable_ctx`` is `True`.
 
+        out_dq : 2D array of int32, None, optional
+            A 2D `~numpy.ndarray` containing DQ bitfields of output (resampled)
+            pixels. It is computed by combining (using bitwise-OR) DQ bitfields
+            of input pixels that contributed to the output pixel.
+            If provided, it must be a 2D array of the same shape as
+            ``out_img``. If `None`, output DQ array will be created during
+            the first call to `add_image` and will be initialized to zero.
+
         exptime : float, optional
             Exposure time of previously resampled images when provided via
             parameters ``out_img``, ``out_wht``, ``out_ctx``.
@@ -262,6 +270,7 @@ class Drizzle:
         """
         self._ncoadds = 0
         self._out_img2 = None
+        self._out_dq = None
         self._disable_ctx = disable_ctx
 
         if disable_ctx:
@@ -328,6 +337,10 @@ class Drizzle:
                 raise ValueError("'out_ctx' must be either a 2D or 3D array.")
             shapes.add(out_ctx.shape[1:])
 
+        if out_dq is not None:
+            out_dq = np.asarray(out_dq, dtype=np.int32)
+            shapes.add(out_dq.shape)
+
         if out_shape is not None:
             shapes.add(tuple(out_shape))
 
@@ -344,7 +357,8 @@ class Drizzle:
         elif len(shapes) > 1:
             raise ValueError(
                 "Inconsistent data shapes specified: 'out_shape' and/or "
-                "out_img, out_img2, out_wht, out_ctx have different shapes."
+                "out_img, out_img2, out_wht, out_ctx, out_dq have different "
+                "shapes."
             )
         else:
             self._out_shape = None
@@ -370,6 +384,14 @@ class Drizzle:
                 )
         self._output_shapes = shapes
         self._alloc_output_arrays2_init(out_img2=out_img2)
+
+        if out_dq is not None:
+            out_dq = np.asarray(out_dq, dtype=np.int32)
+            if out_dq.shape != self._out_shape:
+                raise ValueError(
+                    "'out_dq' must have the same shape as 'out_img'."
+                )
+            self._out_dq = out_dq
 
     @property
     def fillval(self):
@@ -416,6 +438,14 @@ class Drizzle:
 
         """
         return self._out_img2
+
+    @property
+    def out_dq(self):
+        """Output DQ image computed by OR-combining DQ bitfields of input
+        images' pixels that have contributed to a given ouput pixel.
+
+        """
+        return self._out_dq
 
     @property
     def total_exptime(self):
@@ -563,7 +593,7 @@ class Drizzle:
 
         return plane_info
 
-    def add_image(self, data, exptime, pixmap, data2=None, scale=1.0,
+    def add_image(self, data, exptime, pixmap, data2=None, dq=None, scale=1.0,
                   weight_map=None, wht_scale=1.0, pixfrac=1.0, in_units='cps',
                   xmin=None, xmax=None, ymin=None, ymax=None):
         """
@@ -606,6 +636,14 @@ class Drizzle:
                 ``data``. Therefore, when ``in_units`` are "counts",
                 ``data2`` arrays will be rescaled by ``exptime**2`` to convert
                 to rate units before resampling.
+
+        dq : 2D array, None, optional
+            A 2D numpy array containing DQ bitfields of input pixels. It must
+            have the same shape as ``data``. If provided, output DQ array
+            (accessible via ``out_dq`` property) will be computed by combining
+            (using bitwise-OR) DQ bitfields of input pixels that contributed to
+            the output pixel. If `None`, DQ array of the output image will
+            not be computed.
 
         scale : float, optional
             The pixel scale of the input image. Conceptually, this is the
@@ -786,6 +824,15 @@ class Drizzle:
                 raise AssertionError("Context image is expected to be 3D")
             ctx_plane = self._out_ctx[plane_no]
 
+        if dq is not None:
+            dq = np.asarray(dq, dtype=np.int32)
+            if dq.shape != data.shape:
+                raise ValueError(
+                    "'dq' shape is not consistent with 'data' shape."
+                )
+            if self._out_dq is None:
+                self._out_dq = np.zeros(self._out_shape, dtype=np.int32)
+
         # TODO: probably tdriz should be modified to not return version.
         #       we should not have git, Python, C, ... versions
 
@@ -795,13 +842,15 @@ class Drizzle:
 
         _vers, nmiss, nskip = cdrizzle.tdriz(
             input=data,
-            input2=data2,
             weights=weight_map,
             pixmap=pixmap,
             output=self._out_img,
-            output2=self._out_img2,
             counts=self._out_wht,
             context=ctx_plane,
+            input2=data2,
+            output2=self._out_img2,
+            dq=dq,
+            outdq=self._out_dq,
             uniqid=id_in_plane + 1,
             xmin=xmin,
             xmax=xmax,

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -299,7 +299,7 @@ tdriz(PyObject *self, PyObject *args, PyObject *keywords) {
     if (odq == Py_None || odq == NULL) {
         dq = NULL;
     } else {
-        dq = (PyArrayObject *)PyArray_ContiguousFromAny(odq, NPY_INT32, 2, 2);
+        dq = (PyArrayObject *)PyArray_ContiguousFromAny(odq, NPY_UINT32, 2, 2);
         if (!dq) {
             driz_error_set_message(&error, "Invalid input DQ array");
             goto _exit;
@@ -309,13 +309,14 @@ tdriz(PyObject *self, PyObject *args, PyObject *keywords) {
     if (ooutdq == Py_None || ooutdq == NULL) {
         if (dq != NULL) {
             driz_error_set_message(
-                &error, "If 'dq' is provided, 'outdq' must also be provided.");
+                &error,
+                "When 'dq' is provided, 'outdq' must also be provided.");
             goto _exit;
         }
         outdq = NULL;
     } else {
-        outdq =
-            (PyArrayObject *)PyArray_ContiguousFromAny(ooutdq, NPY_INT32, 2, 2);
+        outdq = (PyArrayObject *)PyArray_ContiguousFromAny(ooutdq, NPY_UINT32,
+                                                           2, 2);
         if (!outdq) {
             driz_error_set_message(&error, "Invalid output DQ array");
             goto _exit;

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -86,7 +86,7 @@ update_data(struct driz_param_t *p, const integer_t ii, const integer_t jj,
  */
 inline_macro static int
 update_data_var(struct driz_param_t *p, const integer_t ii, const integer_t jj,
-                const float d, const float dow, float *d2, int dq) {
+                const float d, const float dow, float *d2, unsigned int dq) {
     double vc_plus_dow, vc_plus_dow2;
     double v, vc2, dow2;
     float vc;
@@ -118,7 +118,7 @@ update_data_var(struct driz_param_t *p, const integer_t ii, const integer_t jj,
             }
         }
         if (p->dq) {
-            set_int_pixel(p->output_dq, ii, jj, dq);
+            set_uint_pixel(p->output_dq, ii, jj, dq);
         }
     } else {
         v = (get_pixel(p->output_data, ii, jj) * vc + dow * d) / vc_plus_dow;
@@ -134,8 +134,8 @@ update_data_var(struct driz_param_t *p, const integer_t ii, const integer_t jj,
             }
         }
         if (p->dq) {
-            output_dq_value = get_int_pixel(p->output_dq, ii, jj);
-            set_int_pixel(p->output_dq, ii, jj, output_dq_value | dq);
+            output_dq_value = get_uint_pixel(p->output_dq, ii, jj);
+            set_uint_pixel(p->output_dq, ii, jj, output_dq_value | dq);
         }
     }
     set_pixel(p->output_counts, ii, jj, vc_plus_dow);
@@ -482,8 +482,8 @@ do_kernel_point_var(struct driz_param_t *p) {
     integer_t osize[2];
     float scale2, scale4, d, dow, *d2 = NULL;
     integer_t bv;
-    int xmin, xmax, ymin, ymax, n, dqval = 0;
-    int ndata2;
+    int xmin, xmax, ymin, ymax, n, ndata2;
+    unsigned int dqval = 0;
 
     ndata2 = p->ndata2;
 
@@ -582,7 +582,7 @@ do_kernel_point_var(struct driz_param_t *p) {
                     }
 
                     if (p->dq) {
-                        dqval = (int)get_int_pixel(p->dq, i, j);
+                        dqval = (int)get_uint_pixel(p->dq, i, j);
                     }
 
                     /* If we are creating or modifying the context image,
@@ -620,8 +620,8 @@ do_kernel_gaussian_var(struct driz_param_t *p) {
     double gaussian_efac, gaussian_es;
     double pfo, ac, scale2, scale4, w, ddx, ddy, r2, dover;
     const double nsig = 2.5;
-    int xmin, xmax, ymin, ymax, n, dqval = 0;
-    int ndata2;
+    int xmin, xmax, ymin, ymax, n, ndata2;
+    unsigned int dqval = 0;
 
     ndata2 = p->ndata2;
 
@@ -752,7 +752,7 @@ do_kernel_gaussian_var(struct driz_param_t *p) {
                         }
 
                         if (p->dq) {
-                            dqval = (int)get_int_pixel(p->dq, i, j);
+                            dqval = get_uint_pixel(p->dq, i, j);
                         }
 
                         if (update_data_var(p, ii, jj, d, dow, d2, dqval)) {
@@ -793,8 +793,8 @@ do_kernel_lanczos_var(struct driz_param_t *p) {
     size_t ix, iy;
     double sdp;
     double *lut = NULL;
-    int xmin, xmax, ymin, ymax, n, dqval = 0;
-    int ndata2;
+    int xmin, xmax, ymin, ymax, n, ndata2;
+    unsigned int dqval = 0;
 
     if (fabs(p->pixel_fraction - 1.0) > 1.0e-5) {
         py_warning(
@@ -936,7 +936,7 @@ do_kernel_lanczos_var(struct driz_param_t *p) {
                         }
 
                         if (p->dq) {
-                            dqval = (int)get_int_pixel(p->dq, i, j);
+                            dqval = get_uint_pixel(p->dq, i, j);
                         }
 
                         if (update_data_var(p, ii, jj, d, dow, d2, dqval)) {
@@ -977,8 +977,8 @@ do_kernel_turbo_var(struct driz_param_t *p) {
     float d, dow, *d2 = NULL;
     double pfo, scale2, scale4, ac;
     double xxi, xxa, yyi, yya, w, dover;
-    int xmin, xmax, ymin, ymax, n, dqval = 0;
-    int ndata2;
+    int xmin, xmax, ymin, ymax, n, ndata2;
+    unsigned int dqval = 0;
 
     ndata2 = p->ndata2;
 
@@ -1105,7 +1105,7 @@ do_kernel_turbo_var(struct driz_param_t *p) {
                             }
 
                             if (p->dq) {
-                                dqval = get_int_pixel(p->dq, i, j);
+                                dqval = get_uint_pixel(p->dq, i, j);
                             }
 
                             if (update_data_var(p, ii, jj, d, dow, d2, dqval)) {
@@ -1144,7 +1144,8 @@ do_kernel_square_var(struct driz_param_t *p) {
     double dh, jaco, dover, w;
 
     double xin[4], yin[4], xout[4], yout[4];
-    int ndata2, dqval = 0;
+    int ndata2;
+    unsigned int dqval = 0;
 
     ndata2 = p->ndata2;
 
@@ -1309,7 +1310,7 @@ do_kernel_square_var(struct driz_param_t *p) {
                         }
 
                         if (p->dq) {
-                            dqval = (int)get_int_pixel(p->dq, i, j);
+                            dqval = get_uint_pixel(p->dq, i, j);
                         }
 
                         if (update_data_var(p, ii, jj, d, dow, d2, dqval)) {

--- a/src/cdrizzleutil.c
+++ b/src/cdrizzleutil.c
@@ -162,6 +162,7 @@ driz_param_init(struct driz_param_t *p) {
     /* Input data */
     p->data = NULL;
     p->data2 = NULL;
+    p->dq = NULL;
     p->weights = NULL;
     p->pixmap = NULL;
     p->ndata2 = 0;
@@ -177,6 +178,7 @@ driz_param_init(struct driz_param_t *p) {
     p->output_data2 = NULL;
     p->output_counts = NULL;
     p->output_context = NULL;
+    p->output_dq = NULL;
 
     p->nmiss = 0;
     p->nskip = 0;

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -154,6 +154,7 @@ struct driz_param_t {
     /* Input images */
     PyArrayObject *data;
     PyArrayObject **data2;
+    PyArrayObject *dq;
     PyArrayObject *weights;
     PyArrayObject *pixmap;
 
@@ -162,6 +163,7 @@ struct driz_param_t {
     PyArrayObject **output_data2;
     PyArrayObject *output_counts;
     PyArrayObject *output_context;
+    PyArrayObject *output_dq;
 
     integer_t ndata2;
 
@@ -308,6 +310,11 @@ oob_output_pixel(driz_param_t *p, integer_t xpix, integer_t ypix) {
 
 #endif
 
+static inline_macro int
+get_int_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix) {
+    return *(int *)PyArray_GETPTR2(image, ypix, xpix);
+}
+
 static inline_macro float
 get_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix) {
     return *(float *)PyArray_GETPTR2(image, ypix, xpix);
@@ -323,6 +330,12 @@ get_pixel_at_pos(PyArrayObject *image, integer_t pos) {
 static inline_macro void
 set_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix, double value) {
     *(float *)PyArray_GETPTR2(image, ypix, xpix) = value;
+    return;
+}
+
+static inline_macro void
+set_int_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix, int value) {
+    *(int *)PyArray_GETPTR2(image, ypix, xpix) = value;
     return;
 }
 

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -311,8 +311,8 @@ oob_output_pixel(driz_param_t *p, integer_t xpix, integer_t ypix) {
 #endif
 
 static inline_macro int
-get_int_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix) {
-    return *(int *)PyArray_GETPTR2(image, ypix, xpix);
+get_uint_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix) {
+    return *(unsigned int *)PyArray_GETPTR2(image, ypix, xpix);
 }
 
 static inline_macro float
@@ -334,8 +334,9 @@ set_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix, double value) {
 }
 
 static inline_macro void
-set_int_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix, int value) {
-    *(int *)PyArray_GETPTR2(image, ypix, xpix) = value;
+set_uint_pixel(PyArrayObject *image, integer_t xpix, integer_t ypix,
+               unsigned int value) {
+    *(unsigned int *)PyArray_GETPTR2(image, ypix, xpix) = value;
     return;
 }
 


### PR DESCRIPTION
This PR adds support for propagating DQ bitfields from input images to the output image using bitwise-OR.

Also see https://jira.stsci.edu/browse/AL-982