### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -1147,8 +1147,11 @@ invert_pixmap_wrap(PyObject *self, PyObject *args) {
         return Py_BuildValue("");
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
     PyArrayObject *arr = (PyArrayObject *)PyArray_SimpleNewFromData(
         1, &xyin_dim, NPY_DOUBLE, xyin);
+#pragma GCC diagnostic pop
 
     PyArray_ENABLEFLAGS(arr, NPY_ARRAY_OWNDATA);
     if (free_xyout) {

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -11,9 +11,12 @@
 #define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
 #endif
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <numpy/arrayobject.h>
 #include <numpy/ndarrayobject.h>
 #include <numpy/npy_math.h>
+#pragma GCC diagnostic pop
 
 #include "cdrizzleblot.h"
 #include "cdrizzlebox.h"

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -1,6 +1,5 @@
 #include <Python.h>
 
-#define _USE_MATH_DEFINES /* MS Windows needs to define M_PI */
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
@@ -9,11 +8,8 @@
 #include <stdio.h>
 
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_24_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
 #endif
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpedantic"
 
 #include <numpy/arrayobject.h>
 #include <numpy/ndarrayobject.h>
@@ -24,7 +20,6 @@
 #include "cdrizzlemap.h"
 #include "cdrizzleutil.h"
 #include "tests/drizzletest.h"
-#pragma GCC diagnostic pop
 
 static PyObject *gl_Error;
 FILE *driz_log_handle = NULL;

--- a/src/cdrizzleblot.c
+++ b/src/cdrizzleblot.c
@@ -1,17 +1,17 @@
+#include <assert.h>
+#define _USE_MATH_DEFINES /* needed for MS Windows to define M_PI */
+#include <math.h>
+#include <stdlib.h>
+
 #define NO_IMPORT_ARRAY
-#define NO_IMPORT_ASTROPY_WCS_API
+#define PY_ARRAY_UNIQUE_SYMBOL cdrizzle_blot_api
+#include <numpy/npy_math.h>
+#include <numpy/arrayobject.h>
 
 #include "driz_portability.h"
 #include "cdrizzlemap.h"
 #include "cdrizzleblot.h"
 #include "cdrizzleutil.h"
-
-#include <assert.h>
-#define _USE_MATH_DEFINES /* needed for MS Windows to define M_PI */
-#include <math.h>
-#include <stdlib.h>
-#include <numpy/npy_math.h>
-#include <numpy/arrayobject.h>
 
 static const double lut_delta = 0.003; /* spacing of Lanczos LUT */
 
@@ -580,8 +580,8 @@ interpolate_sinc_(PyArrayObject *data, const integer_t firstt,
     const integer_t nsinc = (nconv - 1) / 2;
     /* TODO: This is to match Fortan, but is probably technically less precise
      */
-    const float halfpi = 1.5707963267948966192f; /* M_PI / 2.0; */
-    const float sconst = powf((halfpi / (float)nsinc), 2.0f);
+
+    const float sconst = powf((float)(M_PI_2 / nsinc), 2.0f);
     const float a2 = -0.49670f;
     const float a4 = 0.03705f;
     float taper[INTERPOLATE_SINC_NCONV];

--- a/src/cdrizzleblot.c
+++ b/src/cdrizzleblot.c
@@ -5,8 +5,12 @@
 
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL cdrizzle_blot_api
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <numpy/npy_math.h>
 #include <numpy/arrayobject.h>
+#pragma GCC diagnostic pop
 
 #include "driz_portability.h"
 #include "cdrizzlemap.h"

--- a/src/cdrizzleblot.c
+++ b/src/cdrizzleblot.c
@@ -3,6 +3,10 @@
 #include <math.h>
 #include <stdlib.h>
 
+#ifndef NPY_NO_DEPRECATED_API
+#define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
+#endif
+
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL cdrizzle_blot_api
 

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -1,15 +1,17 @@
 #define NO_IMPORT_ARRAY
-#define NO_IMPORT_ASTROPY_WCS_API
-
-#include "driz_portability.h"
-#include "cdrizzlemap.h"
-#include "cdrizzlebox.h"
-#include "cdrizzleutil.h"
 
 #include <assert.h>
 #define _USE_MATH_DEFINES /* needed for MS Windows to define M_PI */
 #include <math.h>
 #include <stdlib.h>
+
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL cdrizzle_box_api
+
+#include "driz_portability.h"
+#include "cdrizzlemap.h"
+#include "cdrizzlebox.h"
+#include "cdrizzleutil.h"
 
 static const double lut_delta = 0.003; /* spacing of Lanczos LUT */
 

--- a/src/cdrizzlebox.c
+++ b/src/cdrizzlebox.c
@@ -5,6 +5,10 @@
 #include <math.h>
 #include <stdlib.h>
 
+#ifndef NPY_NO_DEPRECATED_API
+#define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
+#endif
+
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL cdrizzle_box_api
 

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -1,19 +1,23 @@
 #include <assert.h>
+#include <float.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
+
 #include <Python.h>
+
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_24_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
 #endif
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL cdrizzle_map_api
+
 #include <numpy/npy_math.h>
 #include <numpy/arrayobject.h>
 
 #include "driz_portability.h"
 #include "cdrizzlemap.h"
 #include "cdrizzleutil.h"
-
-#include <float.h>
 
 static const double VERTEX_ATOL = 1.0e-12;
 static const double APPROX_ZERO = 1.0e3 * DBL_MIN;

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <Python.h>
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_10_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_24_API_VERSION
 #endif
 #include <numpy/npy_math.h>
 #include <numpy/arrayobject.h>

--- a/src/cdrizzlemap.c
+++ b/src/cdrizzlemap.c
@@ -12,8 +12,11 @@
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL cdrizzle_map_api
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <numpy/npy_math.h>
 #include <numpy/arrayobject.h>
+#pragma GCC diagnostic pop
 
 #include "driz_portability.h"
 #include "cdrizzlemap.h"

--- a/src/cdrizzleutil.c
+++ b/src/cdrizzleutil.c
@@ -1,8 +1,3 @@
-#define NO_IMPORT_ARRAY
-#define NO_IMPORT_ASTROPY_WCS_API
-#include "cdrizzlemap.h"
-#include "cdrizzleutil.h"
-
 #include <assert.h>
 #define _USE_MATH_DEFINES /* needed for MS Windows to define M_PI */
 #include <math.h>
@@ -11,8 +6,17 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef NPY_NO_DEPRECATED_API
+#define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
+#endif
+#define NO_IMPORT_ARRAY
+#define PY_ARRAY_UNIQUE_SYMBOL cdrizzle_util_api
+
 #include <numpy/npy_math.h>
 #include <numpy/arrayobject.h>
+
+#include "cdrizzlemap.h"
+#include "cdrizzleutil.h"
 
 /*****************************************************************
  ERROR HANDLING

--- a/src/cdrizzleutil.c
+++ b/src/cdrizzleutil.c
@@ -12,8 +12,11 @@
 #define NO_IMPORT_ARRAY
 #define PY_ARRAY_UNIQUE_SYMBOL cdrizzle_util_api
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <numpy/npy_math.h>
 #include <numpy/arrayobject.h>
+#pragma GCC diagnostic pop
 
 #include "cdrizzlemap.h"
 #include "cdrizzleutil.h"

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -13,7 +13,10 @@
 #ifndef NPY_NO_DEPRECATED_API
 #define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
 #endif
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <numpy/arrayobject.h>
+#pragma GCC diagnostic pop
 
 /*****************************************************************
  ERROR HANDLING

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -2,20 +2,18 @@
 #define CDRIZZLEUTIL_H
 #include "driz_portability.h"
 
-#include <Python.h>
-#ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_24_API_VERSION
-#endif
-#include <numpy/arrayobject.h>
-
 #include <assert.h>
 #include <errno.h>
-#define _USE_MATH_DEFINES /* needed for MS Windows to define M_PI */
-#include <math.h>
 #if __STDC_VERSION__ >= 199901L
 #include <stdint.h>
 #endif
 #include <stdlib.h>
+
+// #include <Python.h>
+// #ifndef NPY_NO_DEPRECATED_API
+// #define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
+// #endif
+// #include <numpy/arrayobject.h>
 
 /*****************************************************************
  ERROR HANDLING

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -9,11 +9,11 @@
 #endif
 #include <stdlib.h>
 
-// #include <Python.h>
-// #ifndef NPY_NO_DEPRECATED_API
-// #define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
-// #endif
-// #include <numpy/arrayobject.h>
+#include <Python.h>
+#ifndef NPY_NO_DEPRECATED_API
+#define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
+#endif
+#include <numpy/arrayobject.h>
 
 /*****************************************************************
  ERROR HANDLING

--- a/src/cdrizzleutil.h
+++ b/src/cdrizzleutil.h
@@ -4,7 +4,7 @@
 
 #include <Python.h>
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_24_API_VERSION
 #endif
 #include <numpy/arrayobject.h>
 

--- a/src/tests/drizzletest.h
+++ b/src/tests/drizzletest.h
@@ -2,7 +2,7 @@
 
 #include <Python.h>
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_24_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
 #endif
 #include <numpy/arrayobject.h>
 

--- a/src/tests/drizzletest.h
+++ b/src/tests/drizzletest.h
@@ -2,7 +2,7 @@
 
 #include <Python.h>
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_10_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_24_API_VERSION
 #endif
 #include <numpy/arrayobject.h>
 

--- a/src/tests/drizzletest.h
+++ b/src/tests/drizzletest.h
@@ -4,7 +4,10 @@
 #ifndef NPY_NO_DEPRECATED_API
 #define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
 #endif
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <numpy/arrayobject.h>
+#pragma GCC diagnostic pop
 
 int do_kernel_square(struct driz_param_t *p);
 

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -6,8 +6,12 @@
 #ifndef NPY_NO_DEPRECATED_API
 #define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
 #endif
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
 #include <numpy/arrayobject.h>
 #include <numpy/npy_math.h>
+#pragma GCC diagnostic pop
 
 #ifdef WIN32
 #include "fct.h"

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -13,11 +13,14 @@
 #include <numpy/npy_math.h>
 #pragma GCC diagnostic pop
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 #ifdef WIN32
 #include "fct.h"
 #else
 #include "pandokia_fct.h"
 #endif
+#pragma GCC diagnostic pop
 
 #include "cdrizzlebox.h"
 #include "cdrizzleblot.h"

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <Python.h>
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_24_API_VERSION
 #endif
 #include <numpy/arrayobject.h>
 #include <numpy/npy_math.h>

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -15,6 +15,9 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
+// too much work to check whether this is critical (Wmaybe-uninitialized).
+// TODO: consider replacing fct.h with another test framework
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #ifdef WIN32
 #include "fct.h"
 #else

--- a/src/tests/utest_cdrizzle.c
+++ b/src/tests/utest_cdrizzle.c
@@ -4,7 +4,7 @@
 #include <string.h>
 #include <Python.h>
 #ifndef NPY_NO_DEPRECATED_API
-#define NPY_NO_DEPRECATED_API NPY_1_24_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_21_API_VERSION
 #endif
 #include <numpy/arrayobject.h>
 #include <numpy/npy_math.h>


### PR DESCRIPTION
This PR is a partial solution to https://github.com/spacetelescope/drizzle/issues/129

Partially fix some of the compiler warnings. Some warnings related to sinc interpolator will likely need a separate PR as it seems like it will need more effort to check the math (it seems like it was ported from Fortran and in a manner that is wrong in C).

Edit: As an added benefit, this PR also will avoid making copies of input arrays if they have the correct type for that specific array (data, weights, dq, etc.)

Edit: Fortran code for the sinc interpolator contains the same problems, so the sinc-related warnings are not due to language conversion.