### PR TITLE
[SCSB-225] migrate `[tool.pytest.ini_options]` to native TOML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ Documentation = "http://spacetelescope.github.io/drizzle/"
 test = [
     "astropy",
     "gwcs",
-    "pytest",
+    "pytest>=9.0",
     "pytest-cov",
     "pytest-doctestplus",
 ]
@@ -55,8 +55,8 @@ include-package-data = false
 [tool.setuptools.packages.find]
 namespaces = false
 
-[tool.pytest.ini_options]
-minversion = "6"
+[tool.pytest]
+minversion = "9.0"
 norecursedirs = [
     "build",
     "docs/_build",


### PR DESCRIPTION
Resolves [SCSB-225](https://jira.stsci.edu/browse/SCSB-225)

Pytest 9.0 includes a native TOML table `[tool.pytest]`, which we should use instead of `[tool.pytest.ini_options]`