### PR TITLE
Fix tdriz version string to use Python package version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,10 @@
 Release Notes
 =============
 
-2.2.1 (unreleased)
+3.0.0 (unreleased)
 ==================
 
-- Fixed version string of the C-based drizzle code to be set
-  to the version of the Python package. [#219]
+- Removed version string return value from ``cdrizzle.tdriz()``function. [#219]
 
 
 2.2.1 (unreleased)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@
 Release Notes
 =============
 
+2.2.1 (unreleased)
+==================
+
+- Fixed version string of the C-based drizzle code to be set
+  to the version of the Python package. [#219]
+
 
 2.2.1 (unreleased)
 ==================

--- a/drizzle/resample.py
+++ b/drizzle/resample.py
@@ -942,7 +942,7 @@ class Drizzle:
         #       cdrizzleapi.c does not. It should be modified to support this
         #       for performance reasons.
 
-        _vers, nmiss, nskip = cdrizzle.tdriz(
+        nmiss, nskip = cdrizzle.tdriz(
             input=data,
             weights=weight_map,
             pixmap=pixmap,
@@ -969,7 +969,6 @@ class Drizzle:
             fillstr=self._fillval,
             fillstr2=self._fillval2,
         )
-        self._cversion = _vers  # TODO: probably not needed
         self._ncoadds += 1
 
         return nmiss, nskip

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -725,7 +725,7 @@ def test_flux_conservation_nondistorted(kernel, fc, pixel_scale_ratio):
     out_wht = np.zeros(out_shape, dtype=np.float32)
 
     if fc:
-        s, _, _ = cdrizzle.tdriz(
+        cdrizzle.tdriz(
             in_sci,
             in_wht,
             pixmap,
@@ -739,7 +739,7 @@ def test_flux_conservation_nondistorted(kernel, fc, pixel_scale_ratio):
             expscale=1.0,
             wtscale=1.0,
         )
-        assert s.startswith("Callable C-based DRIZZLE Version")
+
     else:
         with pytest.warns(Warning, match=f"Kernel '{kernel}' is not a flux-conserving kernel"):
             cdrizzle.tdriz(

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -725,7 +725,7 @@ def test_flux_conservation_nondistorted(kernel, fc, pixel_scale_ratio):
     out_wht = np.zeros(out_shape, dtype=np.float32)
 
     if fc:
-        s, i1, i2 = cdrizzle.tdriz(
+        s, _, _ = cdrizzle.tdriz(
             in_sci,
             in_wht,
             pixmap,

--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -725,7 +725,7 @@ def test_flux_conservation_nondistorted(kernel, fc, pixel_scale_ratio):
     out_wht = np.zeros(out_shape, dtype=np.float32)
 
     if fc:
-        cdrizzle.tdriz(
+        s, i1, i2 = cdrizzle.tdriz(
             in_sci,
             in_wht,
             pixmap,
@@ -739,6 +739,7 @@ def test_flux_conservation_nondistorted(kernel, fc, pixel_scale_ratio):
             expscale=1.0,
             wtscale=1.0,
         )
+        assert s.startswith("Callable C-based DRIZZLE Version")
     else:
         with pytest.warns(Warning, match=f"Kernel '{kernel}' is not a flux-conserving kernel"):
             cdrizzle.tdriz(

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -24,12 +24,8 @@
 #include "cdrizzleutil.h"
 #include "tests/drizzletest.h"
 
-#define C_VERSION_STR "2.2.1"
-
 static PyObject *gl_Error;
 FILE *driz_log_handle = NULL;
-
-static char version_str[128] = "Callable C-based DRIZZLE Version >= " C_VERSION_STR;
 
 static PyArrayObject *
 ensure_array(PyObject *obj, int npy_type, int min_depth, int max_depth, int *is_copy)
@@ -733,7 +729,7 @@ _exit:
         PyErr_SetString(error.type, driz_error_get_message(&error));
         return NULL;
     } else {
-        return Py_BuildValue("sii", version_str, p.nmiss, p.nskip);
+        return Py_BuildValue("ii", p.nmiss, p.nskip);
     }
 }
 
@@ -1257,22 +1253,6 @@ PyInit_cdrizzle(void)
     }
 
     import_array();
-
-    PyObject *metadata = PyImport_ImportModule("importlib.metadata");
-    if (metadata) {
-        PyObject *version_func = PyObject_GetAttrString(metadata, "version");
-        PyObject *args = PyTuple_Pack(1, PyUnicode_FromString("drizzle"));
-        PyObject *version_obj = PyObject_CallObject(version_func, args);
-
-        if (version_obj) {
-            sprintf(
-                version_str, "Callable C-based DRIZZLE Version %s", PyUnicode_AsUTF8(version_obj));
-            Py_DECREF(version_obj);
-        }
-        Py_XDECREF(args);
-        Py_XDECREF(version_func);
-        Py_DECREF(metadata);
-    }
 
     return m;
 }

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -24,8 +24,12 @@
 #include "cdrizzleutil.h"
 #include "tests/drizzletest.h"
 
+#define C_VERSION_STR "2.2.1"
+
 static PyObject *gl_Error;
 FILE *driz_log_handle = NULL;
+
+static char version_str[128] = "Callable C-based DRIZZLE Version >= " C_VERSION_STR;
 
 static PyArrayObject *
 ensure_array(PyObject *obj, int npy_type, int min_depth, int max_depth, int *is_copy)
@@ -729,7 +733,7 @@ _exit:
         PyErr_SetString(error.type, driz_error_get_message(&error));
         return NULL;
     } else {
-        return Py_BuildValue("sii", "Callable C-based DRIZZLE Version 2.1.0", p.nmiss, p.nskip);
+        return Py_BuildValue("sii", version_str, p.nmiss, p.nskip);
     }
 }
 
@@ -1251,6 +1255,22 @@ initcdrizzle(void)
     }
 
     import_array();
+
+    PyObject *metadata = PyImport_ImportModule("importlib.metadata");
+    if (metadata) {
+        PyObject *version_func = PyObject_GetAttrString(metadata, "version");
+        PyObject *args = PyTuple_Pack(1, PyUnicode_FromString("drizzle"));
+        PyObject *version_obj = PyObject_CallObject(version_func, args);
+
+        if (version_obj) {
+            sprintf(
+                version_str, "Callable C-based DRIZZLE Version %s", PyUnicode_AsUTF8(version_obj));
+            Py_DECREF(version_obj);
+        }
+        Py_XDECREF(args);
+        Py_XDECREF(version_func);
+        Py_DECREF(metadata);
+    }
 }
 
 #else
@@ -1269,6 +1289,23 @@ PyInit_cdrizzle(void)
     }
 
     import_array();
+
+    PyObject *metadata = PyImport_ImportModule("importlib.metadata");
+    if (metadata) {
+        PyObject *version_func = PyObject_GetAttrString(metadata, "version");
+        PyObject *args = PyTuple_Pack(1, PyUnicode_FromString("drizzle"));
+        PyObject *version_obj = PyObject_CallObject(version_func, args);
+
+        if (version_obj) {
+            sprintf(
+                version_str, "Callable C-based DRIZZLE Version %s", PyUnicode_AsUTF8(version_obj));
+            Py_DECREF(version_obj);
+        }
+        Py_XDECREF(args);
+        Py_XDECREF(version_func);
+        Py_DECREF(metadata);
+    }
+
     return m;
 }
 

--- a/src/cdrizzleapi.c
+++ b/src/cdrizzleapi.c
@@ -1205,9 +1205,10 @@ clip_polygon_wrap(PyObject *self, PyObject *args)
     return Py_BuildValue("N", list);
 }
 
-/** ---------------------------------------------------------------------------
- * Table of functions callable from python
- */
+/***************************
+ * MODULE INITIALIZATION
+ ***************************/
+
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
@@ -1215,6 +1216,8 @@ clip_polygon_wrap(PyObject *self, PyObject *args)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-function-type-mismatch"
 #endif
+
+/* Table of functions callable from python */
 
 static struct PyMethodDef cdrizzle_methods[] = {
     {"tdriz", (PyCFunction) (void (*)(void)) tdriz, METH_VARARGS | METH_KEYWORDS,
@@ -1239,41 +1242,6 @@ static struct PyMethodDef cdrizzle_methods[] = {
 #pragma clang diagnostic pop
 #endif
 
-/** ---------------------------------------------------------------------------
- */
-
-#if PY_MAJOR_VERSION < 3
-PyMODINIT_FUNC
-initcdrizzle(void)
-{
-    /* Create the module and add the functions */
-    (void) Py_InitModule("cdrizzle", cdrizzle_methods);
-
-    /* Check for errors */
-    if (PyErr_Occurred()) {
-        Py_FatalError("can't initialize module cdrizzle");
-    }
-
-    import_array();
-
-    PyObject *metadata = PyImport_ImportModule("importlib.metadata");
-    if (metadata) {
-        PyObject *version_func = PyObject_GetAttrString(metadata, "version");
-        PyObject *args = PyTuple_Pack(1, PyUnicode_FromString("drizzle"));
-        PyObject *version_obj = PyObject_CallObject(version_func, args);
-
-        if (version_obj) {
-            sprintf(
-                version_str, "Callable C-based DRIZZLE Version %s", PyUnicode_AsUTF8(version_obj));
-            Py_DECREF(version_obj);
-        }
-        Py_XDECREF(args);
-        Py_XDECREF(version_func);
-        Py_DECREF(metadata);
-    }
-}
-
-#else
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT, "cdrizzle", NULL, -1, cdrizzle_methods, NULL, NULL, NULL, NULL};
 
@@ -1308,5 +1276,3 @@ PyInit_cdrizzle(void)
 
     return m;
 }
-
-#endif


### PR DESCRIPTION
Instead of using a hardcoded in C code version string, `tdriz` will read Python package version and report that as C-version string. If retrieving Python package version fails, the code will revert to the hardcoded version so it is still advisable to keep that version string in sync with Python.

Closes [AL-783](https://jira.stsci.edu/browse/AL-783)