### PR TITLE
Apply clang-format

### DIFF
--- a/src/cdrizzleutil.c
+++ b/src/cdrizzleutil.c
@@ -26,14 +26,16 @@
 */
 
 void
-driz_error_init(struct driz_error_t *error) {
+driz_error_init(struct driz_error_t *error)
+{
     assert(error);
     error->type = NULL;
     error->last_message[0] = 0;
 }
 
 int
-driz_error_check(struct driz_error_t *error, const char *message, int test) {
+driz_error_check(struct driz_error_t *error, const char *message, int test)
+{
     if (!test) {
         driz_error_set_message(error, message);
         return 1;
@@ -43,7 +45,8 @@ driz_error_check(struct driz_error_t *error, const char *message, int test) {
 }
 
 void
-driz_error_set_message(struct driz_error_t *error, const char *message) {
+driz_error_set_message(struct driz_error_t *error, const char *message)
+{
     assert(error);
     assert(message);
 
@@ -52,7 +55,8 @@ driz_error_set_message(struct driz_error_t *error, const char *message) {
 }
 
 void
-driz_error_format_message(struct driz_error_t *error, const char *format, ...) {
+driz_error_format_message(struct driz_error_t *error, const char *format, ...)
+{
     /* See http://c-faq.com/varargs/vprintf.html
        for an explanation of how all this variable length argument list stuff
        works. */
@@ -62,14 +66,14 @@ driz_error_format_message(struct driz_error_t *error, const char *format, ...) {
     assert(format);
 
     va_start(argp, format);
-    (void)vsnprintf(error->last_message, MAX_DRIZ_ERROR_LEN - 1, format, argp);
+    (void) vsnprintf(error->last_message, MAX_DRIZ_ERROR_LEN - 1, format, argp);
     va_end(argp);
     error->last_message[MAX_DRIZ_ERROR_LEN - 1] = '\0';
 }
 
 void
-driz_error_set(struct driz_error_t *error, PyObject *type, const char *format,
-               ...) {
+driz_error_set(struct driz_error_t *error, PyObject *type, const char *format, ...)
+{
     /* See http://c-faq.com/varargs/vprintf.html
        for an explanation of how all this variable length argument list stuff
        works. */
@@ -79,7 +83,7 @@ driz_error_set(struct driz_error_t *error, PyObject *type, const char *format,
     assert(format);
 
     va_start(argp, format);
-    (void)vsnprintf(error->last_message, MAX_DRIZ_ERROR_LEN - 1, format, argp);
+    (void) vsnprintf(error->last_message, MAX_DRIZ_ERROR_LEN - 1, format, argp);
     va_end(argp);
 
     error->last_message[MAX_DRIZ_ERROR_LEN - 1] = '\0';
@@ -87,21 +91,24 @@ driz_error_set(struct driz_error_t *error, PyObject *type, const char *format,
 }
 
 const char *
-driz_error_get_message(struct driz_error_t *error) {
+driz_error_get_message(struct driz_error_t *error)
+{
     assert(error);
 
     return error->last_message;
 }
 
 int
-driz_error_is_set(struct driz_error_t *error) {
+driz_error_is_set(struct driz_error_t *error)
+{
     assert(error);
 
     return error->last_message[0] != 0;
 }
 
 void
-driz_error_unset(struct driz_error_t *error) {
+driz_error_unset(struct driz_error_t *error)
+{
     assert(error);
 
     driz_error_init(error);
@@ -147,13 +154,13 @@ driz_error_unset(struct driz_error_t *error) {
  *     truncated for very long formatted strings.
  */
 int
-py_warning(PyObject *warning_type, const char *format, ...) {
+py_warning(PyObject *warning_type, const char *format, ...)
+{
     char warn_msg[MAX_DRIZ_ERROR_LEN];
     va_list argp;
     va_start(argp, format);
     if (vsnprintf(warn_msg, MAX_DRIZ_ERROR_LEN - 1, format, argp) < 1) {
-        strncpy(warn_msg, "Warning message formatting error.",
-                MAX_DRIZ_ERROR_LEN - 1);
+        strncpy(warn_msg, "Warning message formatting error.", MAX_DRIZ_ERROR_LEN - 1);
     }
     va_end(argp);
 
@@ -170,7 +177,8 @@ py_warning(PyObject *warning_type, const char *format, ...) {
  DATA TYPES
 */
 void
-driz_param_dump(struct driz_param_t *p) {
+driz_param_dump(struct driz_param_t *p)
+{
     assert(p);
 
     printf("DRIZZLING PARAMETERS:\n");
@@ -189,7 +197,8 @@ driz_param_dump(struct driz_param_t *p) {
 }
 
 void
-driz_param_init(struct driz_param_t *p) {
+driz_param_init(struct driz_param_t *p)
+{
     assert(p);
 
     /* Kernel shape and size */
@@ -244,20 +253,19 @@ driz_param_init(struct driz_param_t *p) {
 /*****************************************************************
  STRING TO ENUMERATION CONVERSIONS
 */
-static const char *kernel_string_table[] = {
-    "square", "gaussian", "point", "turbo", "lanczos2", "lanczos3", NULL};
+static const char *kernel_string_table[] = {"square",   "gaussian", "point", "turbo",
+                                            "lanczos2", "lanczos3", NULL};
 
 static const char *unit_string_table[] = {"counts", "cps", NULL};
 
-static const char *interp_string_table[] = {
-    "nearest", "linear", "poly3", "poly5", "spline3",
-    "sinc",    "lsinc",  "lan3",  "lan5",  NULL};
+static const char *interp_string_table[] = {"nearest", "linear", "poly3", "poly5", "spline3",
+                                            "sinc",    "lsinc",  "lan3",  "lan5",  NULL};
 
 static const char *bool_string_table[] = {"FALSE", "TRUE", NULL};
 
 static int
-str2enum(const char *s, const char *table[], int *result,
-         struct driz_error_t *error) {
+str2enum(const char *s, const char *table[], int *result, struct driz_error_t *error)
+{
     const char **it = table;
 
     assert(s);
@@ -277,9 +285,9 @@ str2enum(const char *s, const char *table[], int *result,
 }
 
 int
-kernel_str2enum(const char *s, enum e_kernel_t *result,
-                struct driz_error_t *error) {
-    if (str2enum(s, kernel_string_table, (int *)result, error)) {
+kernel_str2enum(const char *s, enum e_kernel_t *result, struct driz_error_t *error)
+{
+    if (str2enum(s, kernel_string_table, (int *) result, error)) {
         driz_error_format_message(error, "Unknown kernel type '%s'", s);
         return 1;
     }
@@ -288,9 +296,9 @@ kernel_str2enum(const char *s, enum e_kernel_t *result,
 }
 
 int
-unit_str2enum(const char *s, enum e_unit_t *result,
-              struct driz_error_t *error) {
-    if (str2enum(s, unit_string_table, (int *)result, error)) {
+unit_str2enum(const char *s, enum e_unit_t *result, struct driz_error_t *error)
+{
+    if (str2enum(s, unit_string_table, (int *) result, error)) {
         driz_error_format_message(error, "Unknown unit type '%s'", s);
         return 1;
     }
@@ -299,9 +307,9 @@ unit_str2enum(const char *s, enum e_unit_t *result,
 }
 
 int
-interp_str2enum(const char *s, enum e_interp_t *result,
-                struct driz_error_t *error) {
-    if (str2enum(s, interp_string_table, (int *)result, error)) {
+interp_str2enum(const char *s, enum e_interp_t *result, struct driz_error_t *error)
+{
+    if (str2enum(s, interp_string_table, (int *) result, error)) {
         driz_error_format_message(error, "Unknown interp type '%s'", s);
         return 1;
     }
@@ -310,28 +318,32 @@ interp_str2enum(const char *s, enum e_interp_t *result,
 }
 
 const char *
-kernel_enum2str(enum e_kernel_t value) {
+kernel_enum2str(enum e_kernel_t value)
+{
     assert(value >= 0 && value < kernel_LAST);
 
     return kernel_string_table[value];
 }
 
 const char *
-unit_enum2str(enum e_unit_t value) {
+unit_enum2str(enum e_unit_t value)
+{
     assert(value >= 0 && value < 2);
 
     return unit_string_table[value];
 }
 
 const char *
-interp_enum2str(enum e_interp_t value) {
+interp_enum2str(enum e_interp_t value)
+{
     assert(value >= 0 && value < interp_LAST);
 
     return interp_string_table[value];
 }
 
 const char *
-bool2str(bool_t value) {
+bool2str(bool_t value)
+{
     return bool_string_table[value ? 1 : 0];
 }
 
@@ -339,9 +351,9 @@ bool2str(bool_t value) {
  NUMERICAL UTILITIES
 */
 void
-create_lanczos_lut(const int kernel_order, const size_t npix, const double del,
-                   double *lanczos_lut) {
-    double order = (double)kernel_order;
+create_lanczos_lut(const int kernel_order, const size_t npix, const double del, double *lanczos_lut)
+{
+    double order = (double) kernel_order;
     double poff, x, r;
 
     assert(lanczos_lut);
@@ -350,7 +362,7 @@ create_lanczos_lut(const int kernel_order, const size_t npix, const double del,
     lanczos_lut[0] = 1.0;
 
     for (size_t i = 1; i < npix; ++i) {
-        x = (double)i * del;
+        x = (double) i * del;
         if (x <= order) {
             poff = M_PI * x;
             r = poff / order;
@@ -362,7 +374,8 @@ create_lanczos_lut(const int kernel_order, const size_t npix, const double del,
 }
 
 void
-put_fill(struct driz_param_t *p, int fill, int fill2) {
+put_fill(struct driz_param_t *p, int fill, int fill2)
+{
     integer_t i, j, k, osize[2], osize2[2], csize[2];
 
     assert(p);
@@ -376,9 +389,10 @@ put_fill(struct driz_param_t *p, int fill, int fill2) {
     get_dimensions(p->output_data, osize);
     get_dimensions(p->output_counts, csize);
     if (osize[0] != csize[0] || osize[1] != csize[1]) {
-        driz_error_set(p->error, PyExc_ValueError,
-                       "Mismatch between output_data and output_counts "
-                       "array size.");
+        driz_error_set(
+            p->error, PyExc_ValueError,
+            "Mismatch between output_data and output_counts "
+            "array size.");
         return;
     }
 
@@ -386,9 +400,10 @@ put_fill(struct driz_param_t *p, int fill, int fill2) {
         for (k = 0; k < p->ndata2; ++k) {
             get_dimensions(p->output_data2[k], osize2);
             if ((osize2[0] != osize[0]) || (osize2[1] != osize[1])) {
-                driz_error_set(p->error, PyExc_ValueError,
-                               "Mismatch between output_data and output_data2 "
-                               "array size.");
+                driz_error_set(
+                    p->error, PyExc_ValueError,
+                    "Mismatch between output_data and output_data2 "
+                    "array size.");
                 return;
             }
         }
@@ -429,13 +444,14 @@ put_fill(struct driz_param_t *p, int fill, int fill2) {
 }
 
 double
-mgf2(double lambda) {
+mgf2(double lambda)
+{
     double sig, sig2;
 
     sig = 1.0e7 / lambda;
     sig2 = sig * sig;
 
-    return sqrt(1.0 + 2.590355e10 / (5.312993e10 - sig2) +
-                4.4543708e9 / (11.17083e9 - sig2) +
-                4.0838897e5 / (1.766361e5 - sig2));
+    return sqrt(
+        1.0 + 2.590355e10 / (5.312993e10 - sig2) + 4.4543708e9 / (11.17083e9 - sig2) +
+        4.0838897e5 / (1.766361e5 - sig2));
 }


### PR DESCRIPTION
Somehow `cdrizzleutil.c` was omitted from https://github.com/spacetelescope/drizzle/pull/210 This PR applies C style.