### PR TITLE
Make tblot treat NaN pixmap entries as missing instead of erroring

### DIFF
--- a/drizzle/tests/test_resample.py
+++ b/drizzle/tests/test_resample.py
@@ -558,6 +558,25 @@ def test_blot_interpolation(tmpdir, interpolator, test_image_type):
     assert max_diff < 1.0e-5
 
 
+def test_blot_nan_pixmap():
+    """NaN entries in the pixmap (no mapping defined for that output pixel)
+    are treated like an out-of-bounds mapping and filled with ``fillval``
+    instead of raising an error. See issue
+    https://github.com/spacetelescope/drizzle/issues/174
+    """
+    data = np.ones((10, 10), dtype=np.float32)
+    y, x = np.indices((10, 10), dtype=np.float64)
+    pixmap = np.dstack([x, y])
+    pixmap[3, 4] = np.nan
+
+    blotted = resample.blot_image(data, pixmap=pixmap, fillval=42.0)
+
+    assert blotted[3, 4] == 42.0
+    mask = np.ones((10, 10), dtype=bool)
+    mask[3, 4] = False
+    assert np.all(blotted[mask] == 1.0)
+
+
 def test_context_planes():
     """Reproduce error seen in issue #50"""
     shape = (10, 10)
@@ -1460,9 +1479,8 @@ def test_drizzle_weights_squared(kernel, fc):
 @pytest.mark.filterwarnings("ignore:Kernel '")
 @pytest.mark.parametrize(
     "kernel_fc, pscale, weights",
-    (
-        x
-        for x in product(
+    list(
+        product(
             [
                 ("square", True),
                 ("turbo", True),
@@ -1764,9 +1782,8 @@ def test_drizzle_weights_squared_array_shape_mismatch():
 
 @pytest.mark.parametrize(
     "kernel_fc, pscale_ratio, kscale_none",
-    (
-        x
-        for x in product(
+    list(
+        product(
             [
                 ("square", True),
                 ("point", True),
@@ -2097,9 +2114,8 @@ def test_drizzle_dq_propagation_wrong_type():
 
 @pytest.mark.parametrize(
     "kernel, pscale_ratio, use_var",
-    (
-        x
-        for x in product(
+    list(
+        product(
             [
                 "square",
                 "point",

--- a/src/cdrizzleblot.c
+++ b/src/cdrizzleblot.c
@@ -706,12 +706,10 @@ doblot(struct driz_param_t *p)
             xo = (float) get_pixmap(p->pixmap, i, j)[0];
             yo = (float) get_pixmap(p->pixmap, i, j)[1];
 
-            if (npy_isnan(xo) || npy_isnan(yo)) {
-                driz_error_format_message(p->error, "NaN in pixmap[%d,%d]", i, j);
-                return 1;
-            }
-
-            /* Check it is on the input image */
+            /* Check it is on the input image. NaN coordinates (no mapping
+               defined for this output pixel) naturally fail this comparison
+               under IEEE-754 and fall through to the missing-value branch
+               below, same as an out-of-bounds mapping. */
             if (xo >= 0.0 && xo < (float) isize[0] && yo >= 0.0 && yo < (float) isize[1]) {
                 /* Check for look-up-table interpolation */
                 if (interpolate(state, p->data, xo, yo, &v, p->error)) {


### PR DESCRIPTION
The C function doblot() used to raise an error whenever the pixmap contained a NaN, forcing the calling function to substitute values (e.g. -1) before calling. NaN comparisons are always false under IEEE-754, so removing the explicit check lets NaN entries fall through to the existing out-of-bounds branch and get filled with `fillval`, matching how the main drizzle path (map_pixel) already treats undefined mappings that are outside the bounds of the target image.

- drop the NaN error branch in doblot() pixmap bounds check, allowing NaNs to be treated as any other mapping that is out-of-bounds
- add test_blot_nan_pixmap unit test

Bonus: convert generator expressions in parametrized tests to `list` types to fix PytestRemovedIn10Warning

Fixes #174 